### PR TITLE
Fix #132 Invalidate statement creation when a fake explanation has an empty content

### DIFF
--- a/src/main/kotlin/org/elaastic/questions/subject/statement/StatementService.kt
+++ b/src/main/kotlin/org/elaastic/questions/subject/statement/StatementService.kt
@@ -86,7 +86,9 @@ class StatementService(
         removeAllFakeExplanation(statement)
         if(fakeExplanationDataList.isNotEmpty()) {
             fakeExplanationDataList.forEach {
-                addFakeExplanation(statement, it)
+                if(it.content?.isNotEmpty() == true) {
+                    addFakeExplanation(statement, it)
+                }
             }
         }
     }


### PR DESCRIPTION
I propose the following shortcut : 
the fake explanations with empty content are simply ignored.

Currently, we cannot save a question when it has an empty fake explanation as it raises an exception.

It's much easier to just ignore empty explanations than raising an error message.