### PR TITLE
fix: typos on sequence explanations

### DIFF
--- a/src/main/resources/templates/i18n/sequence_fr.properties
+++ b/src/main/resources/templates/i18n/sequence_fr.properties
@@ -174,19 +174,15 @@ sequence.interaction.executionContext.blended=Hybride
 sequence.interaction.executionContext.faceToFace.notice=\
 Le contexte "<strong>Face à face</strong>" correspond à une situation pédagogique se déroulant en classe ou en amphithéâtre.<br/>\
 L'enseignant contrôle le démarrage de la séquence puis le passage aux phases suivantes.<br/>\
-Les apprenants doivent accomplir chaque phase dans le temps imparti et patienter jusqu'à l'ouverture de la\
-phase suivante.
+Les apprenants doivent accomplir chaque phase dans le temps imparti et patienter jusqu'à l'ouverture de la phase suivante.
 sequence.interaction.executionContext.distance.notice=\
 Le contexte "<strong>À distance</strong>" correspond à une situation pédagogique pour laquelle les apprenants sont en situation d'autonomie.<br/>\
 L'enseignant ne contrôle que l'ouverture et la fermeture de la séquence.<br/>\
-Chaque apprenant a la possibilité d'enchaîner les phases de la séquence à son rythme, puis de découvrir immédiatement la présentation\
-des résultats.
+Chaque apprenant a la possibilité d'enchaîner les phases de la séquence à son rythme, puis de découvrir immédiatement la présentation des résultats.
 sequence.interaction.executionContext.blended.notice=\
-Le contexte "<strong>Hybride</strong>" correspond à une situation pédagogique se déroulant à distance suivie d'une restitution\
-des résultats en présentiel.<br/>\
+Le contexte "<strong>Hybride</strong>" correspond à une situation pédagogique se déroulant à distance suivie d'une restitution des résultats en présentiel.<br/>\
 L'enseignant contrôle l'ouverture de la séquence et la publication des résultats.<br/>\
-Les apprenants peuvent enchaîner les deux premières phases à leur rythme mais ne découvriront les résultats\
-qu'au moment de leur publication.
+Les apprenants peuvent enchaîner les deux premières phases à leur rythme mais ne découvriront les résultats qu'au moment de leur publication.
 sequence.interaction.configuration=Configuration
 sequence.interaction.configure.title=Configurer la séquence
 player.sequence.readinteraction.updateAllResults=Mettre à jour les résultats


### PR DESCRIPTION
### Minor fix on typos on the modal the teacher sees before starting the assignment.

Before :

https://github.com/elaastic/elaastic-questions-server/assets/50367862/72eeac16-0d45-4efb-acfd-2500447d744e

After :

https://github.com/elaastic/elaastic-questions-server/assets/50367862/2aa50c95-09f5-4a1c-bd30-a137da48ef41

