### PR TITLE
Fix DRAXO evaluation selection

### DIFF
--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
@@ -95,10 +95,23 @@ class ResponseService(
             } ?: listOf()
 
         } else recommendationService.findAllResponsesOrderedByEvaluationCount(
+            evaluator = user,
             interaction = sequence.getResponseSubmissionInteraction(),
             attemptNum = attempt,
             limit = sequence.getEvaluationSpecification().responseToEvaluateCount
         )
+
+    fun findNextResponseToGrade(sequence: Sequence,
+                                user: User,
+                                attempt: AttemptNum,
+                                excludedIds: List<Long>) =
+        recommendationService.findAllResponsesOrderedByEvaluationCount(
+            evaluator = user,
+            interaction = sequence.getResponseSubmissionInteraction(),
+            attemptNum = attempt,
+            excludedIds = excludedIds,
+            limit = 1
+        ).firstOrNull()
 
     fun hasResponseForUser(learner: User, sequence: Sequence, attempt: AttemptNum = 1) =
         responseRepository.countByLearnerAndInteractionAndAttempt(


### PR DESCRIPTION
- Rework the strategy to select the next explanation to evaluate, considering the configured number of evaluations required per learner
- Do not propose self-evaluation
- Do not evaluate several time the same explanation