### PR TITLE
Feature/moderate draxo feedback

### DIFF
--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
@@ -174,13 +174,17 @@ class ResponseService(
     fun updateMeanGradeAndEvaluationCount(response: Response): Response {
         // TODO Update the stats in one single query
         val res =
-            entityManager.createQuery("select avg(pg.grade) as meanGrade, count(pg.id) as evaluationCount, sum(CASE WHEN pg.type = 'DRAXO' THEN 1 ELSE 0 END) from PeerGrading pg where pg.response = :response")
+            entityManager.createQuery("select count(pg.id) as evaluationCount, sum(CASE WHEN pg.type = 'DRAXO' THEN 1 ELSE 0 END) from PeerGrading pg where pg.response = :response")
                 .setParameter("response", response)
                 .singleResult as Array<Any?>
 
-        response.meanGrade = res[0]?.let { BigDecimal(it as Double).setScale(2, RoundingMode.HALF_UP) }
-        response.evaluationCount = res[1]?.let { (it as Long).toInt() } ?: 0
-        response.draxoEvaluationCount = res[2]?.let { (it as Long).toInt() } ?: 0
+        response.evaluationCount = res[0]?.let { (it as Long).toInt() } ?: 0
+        response.draxoEvaluationCount = res[1]?.let { (it as Long).toInt() } ?: 0
+
+        val meangrade = entityManager.createQuery("select avg(pg.grade) from PeerGrading pg where pg.response = :response and pg.hiddenByTeacher = false")
+            .setParameter("response", response)
+            .singleResult as Double?
+        response.meanGrade = meangrade?.let { BigDecimal(it as Double).setScale(2, RoundingMode.HALF_UP) }
 
         return responseRepository.save(response)
     }

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
@@ -184,7 +184,7 @@ class ResponseService(
         val meangrade = entityManager.createQuery("select avg(pg.grade) from PeerGrading pg where pg.response = :response and pg.hiddenByTeacher = false")
             .setParameter("response", response)
             .singleResult as Double?
-        response.meanGrade = meangrade?.let { BigDecimal(it as Double).setScale(2, RoundingMode.HALF_UP) }
+        response.meanGrade = meangrade?.let { BigDecimal(it).setScale(2, RoundingMode.HALF_UP) }
 
         return responseRepository.save(response)
     }

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/PeerGradingType.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/PeerGradingType.kt
@@ -1,5 +1,11 @@
 package org.elaastic.questions.assignment.sequence.peergrading
 
+/**
+ * The type of peer grading
+ *
+ * @property LIKERT the Likert peer grading
+ * @property DRAXO the Draxo peer grading
+ */
 enum class PeerGradingType {
     LIKERT,
     DRAXO;

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/DraxoGrading.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/DraxoGrading.kt
@@ -2,6 +2,7 @@ package org.elaastic.questions.assignment.sequence.peergrading.draxo
 
 import org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.Criteria
 import org.elaastic.questions.assignment.sequence.peergrading.draxo.option.OptionId
+import java.math.BigDecimal
 
 object DraxoGrading {
 
@@ -23,21 +24,36 @@ object DraxoGrading {
             draxoPeerGrading.criteriaO,
         )
 
+    /**
+     * Compute the grade of a peer grading The grade is the sum of the
+     * values of the criteria, otherwise it is null. If the peer grading is
+     * unDerstandable and one of the other criteria is filled. If the peer
+     * grading is not unDerstandable, the grade is null. If the grader does not
+     * know if the response is Relevant, the grade is null. If the grader has
+     * no opinion on, if he Agreed, the grade is null.
+     *
+     * @param d the unDerstandable criteria
+     * @param r the Relevant criteria
+     * @param a the Agreed criteria
+     * @param x the Exhaustive criteria
+     * @param o the Optimal criteria
+     * @return the grade of the peer grading
+     */
     fun computeGrade(
         d: OptionId?,
         r: OptionId?,
         a: OptionId?,
         x: OptionId?,
         o: OptionId?
-    ) =
+    ): BigDecimal? =
         when {
-            d != Criteria.D[OptionId.YES] -> null
-            listOfNotNull(r, a, x, o).isEmpty() -> null
-            r == Criteria.R[OptionId.DONT_KNOW] -> null
-            a == Criteria.A[OptionId.NO_OPINION] -> null
+            d != Criteria.D[OptionId.YES] -> null // if the peer grading is not unDerstandable, the grade is null
+            listOfNotNull(r, a, x, o).isEmpty() -> null // if the peer grading is unDerstandable but no other criteria are filled, the grade is null
+            r == Criteria.R[OptionId.DONT_KNOW] -> null // if the grader does not know if the response is Relevant, the grade is null
+            a == Criteria.A[OptionId.NO_OPINION] -> null // if the grader has no opinion on, if he Agreed, the grade is null
             else -> Criteria.R.value(r) +
                     Criteria.A.value(a) +
                     Criteria.X.value(x) +
-                    Criteria.O.value(o)
+                    Criteria.O.value(o) // else the grade is the sum of the values of the criteria
         }
 }

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/DraxoPeerGradingController.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/DraxoPeerGradingController.kt
@@ -289,29 +289,6 @@ class DraxoPeerGradingController(
         return responseSubmissionAsynchronous
     }
 
-    @ResponseBody
-    @PostMapping("/content/{id}")
-    fun getContent(
-        authentication: Authentication,
-        model: Model,
-        @PathVariable id: Long
-    ): String {
-        val user: User = authentication.principal as User
-        val evaluation: DraxoPeerGrading = peerGradingService.getDraxoPeerGrading(id)
-
-        val draxoEvaluationModel = DraxoEvaluationModel(
-            0,
-            evaluation,
-            user == evaluation.response.interaction.sequence.assignment!!.owner,
-            responseService.canReactOnFeedbackOfResponse(user, evaluation.response),
-            responseService.canHidePeerGrading(user, evaluation.response)
-        )
-
-        model["draxoEvaluationModel"] = draxoEvaluationModel
-
-        return "player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content::draxoPeerGradingContent"
-    }
-
     /**
      * Response for submission through asynchronous request
      *

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/DraxoPeerGradingController.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/DraxoPeerGradingController.kt
@@ -289,6 +289,29 @@ class DraxoPeerGradingController(
         return responseSubmissionAsynchronous
     }
 
+    @ResponseBody
+    @PostMapping("/content/{id}")
+    fun getContent(
+        authentication: Authentication,
+        model: Model,
+        @PathVariable id: Long
+    ): String {
+        val user: User = authentication.principal as User
+        val evaluation: DraxoPeerGrading = peerGradingService.getDraxoPeerGrading(id)
+
+        val draxoEvaluationModel = DraxoEvaluationModel(
+            0,
+            evaluation,
+            user == evaluation.response.interaction.sequence.assignment!!.owner,
+            responseService.canReactOnFeedbackOfResponse(user, evaluation.response),
+            responseService.canHidePeerGrading(user, evaluation.response)
+        )
+
+        model["draxoEvaluationModel"] = draxoEvaluationModel
+
+        return "player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content::draxoPeerGradingContent"
+    }
+
     /**
      * Response for submission through asynchronous request
      *

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/criteria/Criteria.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/criteria/Criteria.kt
@@ -5,15 +5,27 @@ import org.elaastic.questions.assignment.sequence.peergrading.draxo.option.Optio
 import org.elaastic.questions.assignment.sequence.peergrading.draxo.option.OptionType as Type
 import java.math.BigDecimal
 
+/**
+ * The criteria of the Draxo evaluation
+ *
+ * @property D the criteria unDerstandable
+ * @property R the criteria Relevant
+ * @property A the criteria Agreed
+ * @property X the criteria Exhaustive
+ * @property O the criteria Optimal
+ */
 enum class Criteria(val scale: Map<Id, OptionSpecification>) {
 
     /**
      * unDerstandable
      *
-     * The possible option are:
-     * - NO
-     * - PARTIALLY
-     * - YES
+     * See the possible option :
+     *
+     * | Option | Type | Value |
+     * |--------|----------|-------|
+     * | NO | NEGATIVE | 0 |
+     * | PARTIALLY | NEGATIVE | 0 |
+     * | YES | POSITIVE | 0 |
      */
     D(
         mapOf(
@@ -26,11 +38,14 @@ enum class Criteria(val scale: Map<Id, OptionSpecification>) {
     /**
      * Relevant
      *
-     * The possible option are:
-     * - NO
-     * - PARTIALLY
-     * - YES
-     * - DONT_KNOW
+     * See the possible option :
+     *
+     * | Option | Type | Value |
+     * |--------|----------|-------|
+     * | NO | NEGATIVE | 1 |
+     * | PARTIALLY | NEGATIVE | 1.5 |
+     * | YES | POSITIVE | 2 |
+     * | DONT_KNOW | UNKNOWN | 0 |
      */
     R(
         mapOf(
@@ -44,11 +59,14 @@ enum class Criteria(val scale: Map<Id, OptionSpecification>) {
     /**
      * Agreed
      *
-     * The possible option are:
-     * - NO
-     * - PARTIALLY
-     * - YES
-     * - NO_OPINION
+     * See the possible option :
+     *
+     * | Option | Type | Value |
+     * |--------|----------|-------|
+     * | NO | NEGATIVE | 0 |
+     * | PARTIALLY | NEGATIVE | 1 |
+     * | YES | POSITIVE | 2 |
+     * | NO_OPINION | UNKNOWN | 0 |
      */
     A(
         mapOf(
@@ -62,10 +80,13 @@ enum class Criteria(val scale: Map<Id, OptionSpecification>) {
     /**
      * Exhaustive
      *
-     * The possible option are:
-     * - NO
-     * - YES
-     * - DONT_KNOW
+     * See the possible option :
+     *
+     * | Option | Type | Value |
+     * |--------|----------|-------|
+     * | NO | NEGATIVE | 0 |
+     * | YES | POSITIVE | 0.5 |
+     * | DONT_KNOW | UNKNOWN | 0 |
      */
     X(
         mapOf(
@@ -78,10 +99,13 @@ enum class Criteria(val scale: Map<Id, OptionSpecification>) {
     /**
      * Optimal
      *
-     * The possible option are:
-     * - YES
-     * - NO
-     * - DONT_KNOW
+     * See the possible option :
+     *
+     * | Option | Type | Value |
+     * |--------|----------|-------|
+     * | YES | NEGATIVE | 0 |
+     * | NO | POSITIVE | 0.5 |
+     * | DONT_KNOW | UNKNOWN | 0 |
      */
     O(
         mapOf(
@@ -115,6 +139,12 @@ enum class Criteria(val scale: Map<Id, OptionSpecification>) {
     fun getOptionType(optionId: Id?) =
         if(optionId == null) null else scale.getValue(optionId).type
 
+    /**
+     * Get the value of the option if the option is null, return 0.
+     * @param optionId the id of the option
+     * @return the value of the option
+     * @see OptionSpecification.value
+     */
     fun value(optionId: Id?) =
         if (optionId == null)
             BigDecimal(0)

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/option/OptionId.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/peergrading/draxo/option/OptionId.kt
@@ -3,6 +3,12 @@ package org.elaastic.questions.assignment.sequence.peergrading.draxo.option
 /**
  * OptionId is an enumeration of the possible values for a DraxoPeerGrading criteria.
  *
+ * @property YES
+ * @property NO
+ * @property PARTIALLY
+ * @property DONT_KNOW
+ * @property NO_OPINION
+ *
  * @see org.elaastic.questions.assignment.sequence.peergrading.draxo.DraxoPeerGrading
  */
 enum class OptionId(val codeI18n: String) {

--- a/src/main/resources/static/css/draxo-show.css
+++ b/src/main/resources/static/css/draxo-show.css
@@ -24,21 +24,6 @@
     border-top-width: 0;
 }
 
-.review.hidden {
-    background-color: #E6E6E6;
-}
-
-.ui.icon.button.hidden {
-    background-color: #BFBFBF;
-}
-
-.message-hidden {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    column-gap: 20px;
-}
-
 /*////////////////*/
 
 :root {
@@ -185,6 +170,10 @@
     align-items: center;
 }
 
+.draxo-content {
+    border-top: 1px solid var(--border-color);
+}
+
 /*////////////////*/
 
 .separator {
@@ -226,4 +215,26 @@
     .separator {
         display: none;
     }
+}
+
+/*////////////////*/
+
+.review.hidden {
+    background-color: #E6E6E6;
+}
+
+.ui.icon.button.hidden {
+    background-color: #BFBFBF;
+}
+
+.message-hidden {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    column-gap: 20px;
+}
+
+.review.hidden .ui.label {
+    color: black;
+    background-color: #BFBFBF;
 }

--- a/src/main/resources/static/css/draxo-show.css
+++ b/src/main/resources/static/css/draxo-show.css
@@ -40,6 +40,7 @@
 .message-hidden {
     display: flex;
     justify-content: center;
+    align-items: center;
 }
 
 /*////////////////*/

--- a/src/main/resources/static/css/draxo-show.css
+++ b/src/main/resources/static/css/draxo-show.css
@@ -43,7 +43,7 @@
 
 :root {
     --border-color: #7A7A7A;
-    --default-color: #BDBDBD;
+    --default-color: #757575;
     --default-bg-color: #F2F2F2;
 }
 
@@ -116,13 +116,13 @@
 .custom-step.positive {
     background-color: #99DBBB;
     border: 1px solid var(--border-color);
-    color: #016936;
+    color: #01562d;
 }
 
 .custom-step.negative {
     background-color: #FCB5D0;
     border: 1px solid var(--border-color);
-    color: #B03060;
+    color: #802345;
 }
 
 .custom-step.unknown {

--- a/src/main/resources/static/css/draxo-show.css
+++ b/src/main/resources/static/css/draxo-show.css
@@ -41,6 +41,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    column-gap: 20px;
 }
 
 /*////////////////*/

--- a/src/main/resources/static/css/draxo-show.css
+++ b/src/main/resources/static/css/draxo-show.css
@@ -5,6 +5,7 @@
     display: inline-block !important;
     margin-bottom: 1em;
     width: 100%;
+    border: 1px solid var(--border-color);
 }
 
 .review-header {
@@ -15,18 +16,12 @@
 }
 
 .review-border {
-    border: 1px solid var(--border-color);
-    border-bottom-width: 0;
+    border-top: 1px solid var(--border-color);
     padding: 10px 20px;
 }
 
 .review-border:first-child {
-    border-radius: 10px 10px 0 0;
-}
-
-.review-border:last-child {
-    border-radius: 0 0 10px 10px;
-    border-bottom-width: 1px;
+    border-top-width: 0;
 }
 
 .review.hidden {

--- a/src/main/resources/templates/player/assignment/sequence/components/peer-grading-reaction/_peer-grading-draxo-reaction.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/peer-grading-reaction/_peer-grading-draxo-reaction.html
@@ -58,7 +58,7 @@
         </div>
         <div id="submit-button-utility-grade"
              th:attr="data-evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}">
-            <input type="submit" value="Soumettre" class="ui primary button" th:value="#{common.submit}">
+            <button type="submit" value="Soumettre" class="ui primary button" th:text="#{common.submit}"></button>
         </div>
         <div class="ui message" th:attr="data-evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
              id="submit-message">
@@ -105,6 +105,8 @@
                 const url = form.attr('action')
                 const data = form.serialize()
 
+                $('#submit-button-utility-grade[data-evaluation-id="' + evaluationId + '"]').children('button').addClass("loading")
+
                 $.post(url, data, function (response) {
                     if (response.success) {
                         $('#submit-button-utility-grade[data-evaluation-id="' + evaluationId + '"]').slideUp()
@@ -113,6 +115,7 @@
                         submitMessage.addClass("negative")
                         submitMessage.children('.header').css("color", " #9f3a38")
                     }
+                    $('#submit-button-utility-grade[data-evaluation-id="' + evaluationId + '"]').children('button').removeClass("loading")
                     //Update the submit message with the content of the response
                     submitMessage.children('.header').text(response.header)
                     submitMessage.children('.content').text(response.content)

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
@@ -1,0 +1,65 @@
+<!--
+  ~ Elaastic - formative assessment system
+  ~ Copyright (C) 2019. University Toulouse 1 Capitole, University Toulouse 3 Paul Sabatier
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<!-- This fragment is used to display the content of a draxo evaluation -->
+<div xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html"
+     th:fragment="draxoPeerGradingContent(draxoEvaluationModel)"
+     class="review-DRAXO review-border"
+     th:if="${!draxoEvaluationModel.hiddenByTeacher && !(draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}">
+
+    <h4 th:text="#{draxo.evaluationGrid}">Evaluation grid</h4>
+    <div class="DRAXO-grid">
+        <th:block
+                th:each="criteria : ${T(org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.Criteria).values()}"
+                th:with="optionType = ${criteria.getOptionType(draxoEvaluationModel.draxoEvaluation.get(criteria))}">
+
+            <div class="custom-step"
+                 th:classappend="${optionType?.getCSSClass()}">
+
+                <div class="custom-step-content">
+                    <span class="capital-letter" th:text="${criteria}">R</span>
+                    <span th:text="#{${criteria.getMessageI18nKey(T(org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.CriteriaMessageKey).Header)}}">...</span>
+
+                    <i class="green check icon" th:if="${optionType?.name == 'POSITIVE'}"></i>
+                    <i class="red x icon" th:if="${optionType?.name == 'NEGATIVE'}"></i>
+                    <i class="question icon" th:if="${optionType?.name == 'UNKNOWN'}"></i>
+                </div>
+            </div>
+        </th:block>
+    </div>
+
+    <th:block th:with="rejectedCriteria = ${draxoEvaluationModel.draxoEvaluation.getRejectedCriteria()}">
+        <div class="comment-area" th:if="${rejectedCriteria}">
+            <div class="comment-header">
+                <h4 th:text="#{${rejectedCriteria.getMessageI18nKey(T(org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.CriteriaMessageKey).Question)}}+' :'">
+                    The answer is readable :</h4>
+                <div class="ui label"
+                     th:text="#{${draxoEvaluationModel.draxoEvaluation.get(rejectedCriteria).codeI18n}}">
+                    No
+                </div>
+            </div>
+            <div class="separator" th:if="${draxoEvaluationModel.draxoEvaluation.getExplanation()}"></div>
+            <div class="comment" th:if="${draxoEvaluationModel.draxoEvaluation.getExplanation()}">
+                <h4 th:text="#{draxo.feedback.label}">Feedback:</h4>
+                <div class="ui label" th:text="${draxoEvaluationModel.draxoEvaluation.getExplanation()}">
+                    I am a relevant and constructive comment, to explain why the answer provided above
+                    is not decipherable.
+                </div>
+            </div>
+        </div>
+    </th:block>
+</div>

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
@@ -34,8 +34,8 @@
                     <span class="capital-letter" th:text="${criteria}">R</span>
                     <span th:text="#{${criteria.getMessageI18nKey(T(org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.CriteriaMessageKey).Header)}}">...</span>
 
-                    <i class="green check icon" th:if="${optionType?.name == 'POSITIVE'}"></i>
-                    <i class="red x icon" th:if="${optionType?.name == 'NEGATIVE'}"></i>
+                    <i class="check icon" th:if="${optionType?.name == 'POSITIVE'}"></i>
+                    <i class="x icon" th:if="${optionType?.name == 'NEGATIVE'}"></i>
                     <i class="question icon" th:if="${optionType?.name == 'UNKNOWN'}"></i>
                 </div>
             </div>

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
@@ -18,7 +18,7 @@
 <!-- This fragment is used to display the content of a draxo evaluation -->
 <div xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html"
      th:fragment="draxoPeerGradingContent(draxoEvaluationModel)"
-     class="review-DRAXO"
+     class="review-DRAXO review-border"
      >
 
     <h4 th:text="#{draxo.evaluationGrid}">Evaluation grid</h4>

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html
@@ -18,8 +18,8 @@
 <!-- This fragment is used to display the content of a draxo evaluation -->
 <div xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html"
      th:fragment="draxoPeerGradingContent(draxoEvaluationModel)"
-     class="review-DRAXO review-border"
-     th:if="${!draxoEvaluationModel.hiddenByTeacher && !(draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}">
+     class="review-DRAXO"
+     >
 
     <h4 th:text="#{draxo.evaluationGrid}">Evaluation grid</h4>
     <div class="DRAXO-grid">

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -101,49 +101,49 @@
     </div>
 
     <script th:inline="javascript">
+        /**
+         * Update the peer grading visibility through asynchronous request
+         * @param peerGradingID the ID of the peer grading to hide
+         * @param markAsHidden if true, the peer grading will be marked as hidden else it will be marked as unhidden
+         */
+        function updateVisibilityOfPeerGrading(peerGradingID, markAsHidden = true) {
+            const feedbackMessage = $('#feedbackMessage[data-evaluation-id="' + peerGradingID + '"]');
+            /*<![CDATA[*/
+            const responseId = [[${draxoEvaluationModel.responseId}]]
+            /*]]> */
+            let url = "/peer-grading/draxo/";
+            url += markAsHidden ? "hide/" : "unhide/";
+            url += peerGradingID;
 
+            $.get(url, function (data) {
+                if (data.success) {
+                    // We update the container through the link of the detail
+                    const explanationContainer = $('.explanation[data-response-id="' + responseId + '"]:visible')
+                    for (const explanationContainerElement of explanationContainer) {
+                        // If the explanation container has reviews, we click on the detail link, to reload it
+                        if ($(explanationContainerElement).children('.reviews-container').html() !== "") {
+                            $(explanationContainerElement).find('.detail-link').click();
+                        }
+                    }
+                } else {
+                    feedbackMessage.children('.header').css("color", " #9f3a38")
+                    feedbackMessage.children('.header').text(data.header);
+                    feedbackMessage.children('.content').text(data.content);
+
+                    feedbackMessage.slideDown()
+                    setTimeout(function () {
+                        feedbackMessage.slideUp()
+                    }, 5000)
+                }
+            });
+        }
 
         $(function () {
 
             /*<![CDATA[*/
-            const responseId = [[${draxoEvaluationModel.responseId}]]
             const peerGradingID = [[${draxoEvaluationModel.draxoPeerGradingId}]]
-
             /*]]> */
 
-            /**
-             * Update the peer grading visibility through asynchronous request
-             * @param peerGradingID the ID of the peer grading to hide
-             * @param markAsHidden if true, the peer grading will be marked as hidden else it will be marked as unhidden
-             */
-            function updateVisibilityOfPeerGrading(peerGradingID, markAsHidden = true) {
-                const feedbackMessage = $('#feedbackMessage[data-evaluation-id="' + peerGradingID + '"]');
-                let url = "/peer-grading/draxo/";
-                url += markAsHidden ? "hide/" : "unhide/";
-                url += peerGradingID;
-
-                $.get(url, function (data) {
-                    if (data.success) {
-                        // We update the container through the link of the detail
-                        const explanationContainer = $('.explanation[data-response-id="' + responseId + '"]:visible')
-                        for (const explanationContainerElement of explanationContainer) {
-                            // If the explanation container has reviews, we click on the detail link, to reload it
-                            if ($(explanationContainerElement).children('.reviews-container').html() !== "") {
-                                $(explanationContainerElement).find('.detail-link').click();
-                            }
-                        }
-                    } else {
-                        feedbackMessage.children('.header').css("color", " #9f3a38")
-                        feedbackMessage.children('.header').text(data.header);
-                        feedbackMessage.children('.content').text(data.content);
-
-                        feedbackMessage.slideDown()
-                        setTimeout(function () {
-                            feedbackMessage.slideUp()
-                        }, 5000)
-                    }
-                });
-            }
 
             // Display the hidden content when the teacher wants to see it
             const area = $('#draxoContent[evaluation-id="' + peerGradingID + '"]');

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -102,44 +102,83 @@
 
     <script th:inline="javascript">
 
-        /**
-         * Update the peer grading visibility through asynchronous request
-         * @param peerGradingID the ID of the peer grading to hide
-         * @param markAsHidden if true, the peer grading will be marked as hidden else it will be marked as unhidden
-         */
-        function updateVisibilityOfPeerGrading(peerGradingID, markAsHidden = true) {
+
+        $(function () {
+
             /*<![CDATA[*/
             const responseId = [[${draxoEvaluationModel.responseId}]]
-            /*]]> */
-            console.log("hidePeerGrading");
-            console.log(peerGradingID);
-            const feedbackMessage = $('#feedbackMessage[data-evaluation-id="' + peerGradingID + '"]');
-            let url = "/peer-grading/draxo/";
-            url += markAsHidden ? "hide/" : "unhide/";
-            url += peerGradingID;
+            const peerGradingID = [[${draxoEvaluationModel.draxoPeerGradingId}]]
 
-            $.get(url, function (data) {
-                if (data.success) {
-                    // We update the container through the link of the detail
-                    const explanationContainer = $('.explanation[data-response-id="' + responseId + '"]:visible')
-                    for (const explanationContainerElement of explanationContainer) {
-                        // If the explanation container has reviews, we click on the detail link, to reload it
-                        if ($(explanationContainerElement).children('.reviews-container').html() !== "") {
-                            $(explanationContainerElement).find('.detail-link').click();
+            /*]]> */
+
+            /**
+             * Update the peer grading visibility through asynchronous request
+             * @param peerGradingID the ID of the peer grading to hide
+             * @param markAsHidden if true, the peer grading will be marked as hidden else it will be marked as unhidden
+             */
+            function updateVisibilityOfPeerGrading(peerGradingID, markAsHidden = true) {
+                const feedbackMessage = $('#feedbackMessage[data-evaluation-id="' + peerGradingID + '"]');
+                let url = "/peer-grading/draxo/";
+                url += markAsHidden ? "hide/" : "unhide/";
+                url += peerGradingID;
+
+                $.get(url, function (data) {
+                    if (data.success) {
+                        // We update the container through the link of the detail
+                        const explanationContainer = $('.explanation[data-response-id="' + responseId + '"]:visible')
+                        for (const explanationContainerElement of explanationContainer) {
+                            // If the explanation container has reviews, we click on the detail link, to reload it
+                            if ($(explanationContainerElement).children('.reviews-container').html() !== "") {
+                                $(explanationContainerElement).find('.detail-link').click();
+                            }
                         }
+                    } else {
+                        feedbackMessage.children('.header').css("color", " #9f3a38")
+                        feedbackMessage.children('.header').text(data.header);
+                        feedbackMessage.children('.content').text(data.content);
+
+                        feedbackMessage.slideDown()
+                        setTimeout(function () {
+                            feedbackMessage.slideUp()
+                        }, 5000)
+                    }
+                });
+            }
+
+            // Display the hidden content when the teacher wants to see it
+            const area = $('#draxoContent[evaluation-id="' + peerGradingID + '"]');
+            const toggleContentBtn = $('#toggleContentDisplay[evaluation-id="' + peerGradingID + '"]');
+            const showBtn = toggleContentBtn.children('#show');
+            const hideBtn = toggleContentBtn.children('#hide');
+
+            toggleContentBtn.click(function () {
+                if (showBtn.is(':visible')) {
+                    console.log("show")
+                    toggleContentBtn.addClass("loading");
+                    if (area.html() === "") {
+                        console.log("load")
+                        $.post("/peer-grading/draxo/content/" + peerGradingID, function (data) {
+                            area.html(data);
+                            area.slideDown();
+                            toggleContentBtn.removeClass("loading");
+                            showBtn.hide();
+                            hideBtn.show();
+                        });
+                    } else {
+                        console.log("display")
+                        area.slideDown();
+                        toggleContentBtn.removeClass("loading");
+                        showBtn.hide();
+                        hideBtn.show();
                     }
                 } else {
-                    feedbackMessage.children('.header').css("color", " #9f3a38")
-                    feedbackMessage.children('.header').text(data.header);
-                    feedbackMessage.children('.content').text(data.content);
-
-                    feedbackMessage.slideDown()
-                    setTimeout(function () {
-                        feedbackMessage.slideUp()
-                    }, 5000)
+                    console.log("hide")
+                    showBtn.show();
+                    hideBtn.hide();
+                    area.slideUp();
                 }
             });
-        }
+        });
     </script>
 
 </div>

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -23,6 +23,7 @@
 
     <div class="review" th:with="explanation = ${draxoEvaluationModel.draxoEvaluation.getExplanation()}"
          th:classappend="${draxoEvaluationModel.hiddenByTeacher || (draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)} ? 'hidden' : ''">
+        <!--/* PeerGrading header */-->
         <div class="review-header review-border">
             <div class="reviewer">
                 <span th:text="#{draxo.reviewer} + ' :'">Reviewer</span>
@@ -54,6 +55,14 @@
                 </a>
             </div>
         </div>
+        <!--/* Hidden message when the teacher hides it */-->
+        <div class="review-border message-hidden" th:if="${draxoEvaluationModel.hiddenByTeacher}">
+            <div th:text="#{draxo.hiddenByTeacher}">Hidden by the teacher</div>
+            <div class="ui button primary basic">
+                Voir le contenu masqu&eacute;
+            </div>
+        </div>
+        <!--/* Grid Draxo */-->
         <div class="review-DRAXO review-border"
              th:if="${!draxoEvaluationModel.hiddenByTeacher && !(draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}">
             <h4 th:text="#{draxo.evaluationGrid}">Evaluation grid</h4>
@@ -98,21 +107,21 @@
                 </div>
             </th:block>
         </div>
+        <!--/* Reaction for the feedback */-->
         <div class="review-border"
              th:if="${draxoEvaluationModel.canReactOnPeerGrading && draxoEvaluationModel.canBeReacted()}">
-            <!--/* Reaction for the feedback */-->
-            <th:block th:replace="player/assignment/sequence/components/peer-grading-reaction/_peer-grading-draxo-reaction.html :: peerGradingEvaluationCommand(${draxoEvaluationModel})">
+            <th:block
+                    th:replace="player/assignment/sequence/components/peer-grading-reaction/_peer-grading-draxo-reaction.html :: peerGradingEvaluationCommand(${draxoEvaluationModel})">
             </th:block>
         </div>
-        <div class="review-border message-hidden" th:if="${draxoEvaluationModel.hiddenByTeacher}">
-            <div th:text="#{draxo.hiddenByTeacher}">Hidden by the teacher</div>
-        </div>
+        <!--/* Hidden message when the student reports it */-->
         <div class="review-border message-hidden"
              th:if="${!draxoEvaluationModel.hiddenByTeacher && (draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}"
         >
             <div th:text="#{draxo.hiddenByYouReport}">As you reported this evaluation, it is hidden to you.</div>
         </div>
     </div>
+    <!--/* Graphical feedback when the teacher hide a peergrading */-->
     <div class="ui message negative" th:attr="data-evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
          id="feedbackMessage"
          style="display: none;"

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -25,15 +25,18 @@
          th:classappend="${draxoEvaluationModel.hiddenByTeacher || (draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)} ? 'hidden' : ''">
         <!--/* PeerGrading header */-->
         <div class="review-header review-border">
+            <!--/* Reviewer */-->
             <div class="reviewer">
                 <span th:text="#{draxo.reviewer} + ' :'">Reviewer</span>
                 <span class="ui label" th:styleappend="${hideName} ? 'display: none'"
                       th:text="${draxoEvaluationModel.userCanDisplayStudentsIdentity} ? ${draxoEvaluationModel.graderName} : ${draxoEvaluationModel.graderNum}"></span>
             </div>
+            <!--/* Score */-->
             <div class="score" th:if="${!draxoEvaluationModel.hiddenByTeacher}">
                 <span th:text="#{draxo.score} + ' :'">Score</span>
                 <span class="ui label" th:text="${draxoEvaluationModel.score ?: '-'}">2.5</span>
             </div>
+            <!--/* Action de masquage */-->
             <div class="hide-peer-grading" th:if="${draxoEvaluationModel.canHidePeerGrading}">
                 <a class="ui icon button"
                    th:if="${!draxoEvaluationModel.hiddenByTeacher}"
@@ -84,21 +87,21 @@
             <th:block
                     th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
         </div>
-        <!--/* Reaction for the feedback */-->
+        <!--/* Reaction for the DraxoPeerGrading */-->
         <div class="review-border"
              th:if="${draxoEvaluationModel.canReactOnPeerGrading && draxoEvaluationModel.canBeReacted()}">
             <th:block
                     th:replace="player/assignment/sequence/components/peer-grading-reaction/_peer-grading-draxo-reaction.html :: peerGradingEvaluationCommand(${draxoEvaluationModel})">
             </th:block>
         </div>
-        <!--/* Hidden message when the student reports it */-->
+        <!--/* Feedback message when the student reports the DraxoPeerGrading */-->
         <div class="review-border message-hidden"
              th:if="${!draxoEvaluationModel.hiddenByTeacher && (draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}"
         >
             <div th:text="#{draxo.hiddenByYouReport}">As you reported this evaluation, it is hidden to you.</div>
         </div>
     </div>
-    <!--/* Graphical feedback when the teacher hides a peergrading */-->
+    <!--/* Feedback message when the teacher hides a peergrading */-->
     <div class="ui message negative" th:attr="data-evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
          id="feedbackMessage"
          style="display: none;"

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -58,55 +58,13 @@
         <!--/* Hidden message when the teacher hides it */-->
         <div class="review-border message-hidden" th:if="${draxoEvaluationModel.hiddenByTeacher}">
             <div th:text="#{draxo.hiddenByTeacher}">Hidden by the teacher</div>
-            <div class="ui button primary basic">
-                Voir le contenu masqu&eacute;
+            <div class="ui button black basic" style="text-transform: none; font-weight: initial">
+                <span id="show">Voir le contenu masqu&eacute;</span>
+                <span id="hide" style="display: none;">Cacher le contenu masqu&eacute;</span>
             </div>
         </div>
         <!--/* Grid Draxo */-->
-        <div class="review-DRAXO review-border"
-             th:if="${!draxoEvaluationModel.hiddenByTeacher && !(draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}">
-            <h4 th:text="#{draxo.evaluationGrid}">Evaluation grid</h4>
-            <div class="DRAXO-grid">
-                <th:block
-                        th:each="criteria : ${T(org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.Criteria).values()}"
-                        th:with="optionType = ${criteria.getOptionType(draxoEvaluationModel.draxoEvaluation.get(criteria))}">
-
-                    <div class="custom-step"
-                         th:classappend="${optionType?.getCSSClass()}">
-
-                        <div class="custom-step-content">
-                            <span class="capital-letter" th:text="${criteria}">R</span>
-                            <span th:text="#{${criteria.getMessageI18nKey(T(org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.CriteriaMessageKey).Header)}}">...</span>
-
-                            <i class="green check icon" th:if="${optionType?.name == 'POSITIVE'}"></i>
-                            <i class="red x icon" th:if="${optionType?.name == 'NEGATIVE'}"></i>
-                            <i class="question icon" th:if="${optionType?.name == 'UNKNOWN'}"></i>
-                        </div>
-                    </div>
-                </th:block>
-            </div>
-
-            <th:block th:with="rejectedCriteria = ${draxoEvaluationModel.draxoEvaluation.getRejectedCriteria()}">
-                <div class="comment-area" th:if="${rejectedCriteria}">
-                    <div class="comment-header">
-                        <h4 th:text="#{${rejectedCriteria.getMessageI18nKey(T(org.elaastic.questions.assignment.sequence.peergrading.draxo.criteria.CriteriaMessageKey).Question)}}+' :'">
-                            The answer is readable :</h4>
-                        <div class="ui label"
-                             th:text="#{${draxoEvaluationModel.draxoEvaluation.get(rejectedCriteria).codeI18n}}">
-                            No
-                        </div>
-                    </div>
-                    <div class="separator" th:if="${draxoEvaluationModel.draxoEvaluation.getExplanation()}"></div>
-                    <div class="comment" th:if="${draxoEvaluationModel.draxoEvaluation.getExplanation()}">
-                        <h4 th:text="#{draxo.feedback.label}">Feedback:</h4>
-                        <div class="ui label" th:text="${draxoEvaluationModel.draxoEvaluation.getExplanation()}">
-                            I am a relevant and constructive comment, to explain why the answer provided above
-                            is not decipherable.
-                        </div>
-                    </div>
-                </div>
-            </th:block>
-        </div>
+        <th:block th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
         <!--/* Reaction for the feedback */-->
         <div class="review-border"
              th:if="${draxoEvaluationModel.canReactOnPeerGrading && draxoEvaluationModel.canBeReacted()}">

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -55,16 +55,28 @@
                 </a>
             </div>
         </div>
-        <!--/* Hidden message when the teacher hides it */-->
+        <!--/*
+        Hidden message when the teacher hides it.
+        It's only visible by the teacher because if an evaluation is hidden, only the teacher can see it.
+        */-->
         <div class="review-border message-hidden" th:if="${draxoEvaluationModel.hiddenByTeacher}">
             <div th:text="#{draxo.hiddenByTeacher}">Hidden by the teacher</div>
-            <div class="ui button black basic" style="text-transform: none; font-weight: initial">
+            <div id="toggleContentDisplay" class="ui button black basic"
+                 style="text-transform: none; font-weight: initial"
+                 th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}">
                 <span id="show">Voir le contenu masqu&eacute;</span>
                 <span id="hide" style="display: none;">Cacher le contenu masqu&eacute;</span>
             </div>
         </div>
         <!--/* Grid Draxo */-->
-        <th:block th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
+        <th:block
+                th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
+        <!--/*
+        Area to put the DRAXO grid if the teacher wants to see the moderate content.
+        It is visible only if the evaluation is hidden
+        */-->
+        <div th:id="draxoContent" th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
+             th:if="${draxoEvaluationModel.hiddenByTeacher}"></div>
         <!--/* Reaction for the feedback */-->
         <div class="review-border"
              th:if="${draxoEvaluationModel.canReactOnPeerGrading && draxoEvaluationModel.canBeReacted()}">
@@ -79,7 +91,7 @@
             <div th:text="#{draxo.hiddenByYouReport}">As you reported this evaluation, it is hidden to you.</div>
         </div>
     </div>
-    <!--/* Graphical feedback when the teacher hide a peergrading */-->
+    <!--/* Graphical feedback when the teacher hides a peergrading */-->
     <div class="ui message negative" th:attr="data-evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
          id="feedbackMessage"
          style="display: none;"

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -69,14 +69,21 @@
             </div>
         </div>
         <!--/* Grid Draxo */-->
-        <th:block
-                th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
+        <div th:if="${!draxoEvaluationModel.hiddenByTeacher && !(draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}"
+             class="draxo-content">
+            <th:block
+                    th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
+        </div>
         <!--/*
         Area to put the DRAXO grid if the teacher wants to see the moderate content.
         It is visible only if the evaluation is hidden
         */-->
-        <div th:id="draxoContent" th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
-             th:if="${draxoEvaluationModel.hiddenByTeacher}"></div>
+        <div class="draxo-content" th:id="draxoContent"
+             th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
+             th:if="${draxoEvaluationModel.hiddenByTeacher}">
+            <th:block
+                    th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
+        </div>
         <!--/* Reaction for the feedback */-->
         <div class="review-border"
              th:if="${draxoEvaluationModel.canReactOnPeerGrading && draxoEvaluationModel.canBeReacted()}">
@@ -147,6 +154,7 @@
 
             // Display the hidden content when the teacher wants to see it
             const area = $('#draxoContent[evaluation-id="' + peerGradingID + '"]');
+            area.hide();
             const toggleContentBtn = $('#toggleContentDisplay[evaluation-id="' + peerGradingID + '"]');
             const showBtn = toggleContentBtn.children('#show');
             const hideBtn = toggleContentBtn.children('#hide');
@@ -154,28 +162,14 @@
             toggleContentBtn.click(function () {
                 if (showBtn.is(':visible')) {
                     console.log("show")
-                    toggleContentBtn.addClass("loading");
-                    if (area.html() === "") {
-                        console.log("load")
-                        $.post("/peer-grading/draxo/content/" + peerGradingID, function (data) {
-                            area.html(data);
-                            area.slideDown();
-                            toggleContentBtn.removeClass("loading");
-                            showBtn.hide();
-                            hideBtn.show();
-                        });
-                    } else {
-                        console.log("display")
-                        area.slideDown();
-                        toggleContentBtn.removeClass("loading");
-                        showBtn.hide();
-                        hideBtn.show();
-                    }
+                    area.slideDown();
+                    showBtn.hide();
+                    hideBtn.show();
                 } else {
                     console.log("hide")
+                    area.slideUp();
                     showBtn.show();
                     hideBtn.hide();
-                    area.slideUp();
                 }
             });
         });

--- a/src/test/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseServiceIntegrationTest.kt
@@ -836,7 +836,7 @@ internal class ResponseServiceIntegrationTest(
 
         responseService.updateMeanGradeAndEvaluationCount(response)
         assertEquals(0, response.evaluationCount, "The response doesn't have any peergrading")
-        assertEquals(BigDecimal(0), response.meanGrade?:BigDecimal(0), "The mean grade is 0")
+        assertNull(response.meanGrade, "The mean grade is null")
 
         tGiven("An assignement own by the teacher and a peerGrading of the response") {
             DraxoPeerGrading(
@@ -862,7 +862,7 @@ internal class ResponseServiceIntegrationTest(
             peerGradingService.markAsHidden(teacher, peerGrading)
             peerGrading
         }.tThen("The compute mean grade is 0") { peerGrading ->
-            assertEquals(BigDecimal(0), response.meanGrade, "The mean grade is 0")
+            assertNull(response.meanGrade, "The mean grade is null")
             peerGrading
         }.tWhen("the teacher unhide the peerGrading") { peerGrading ->
             peerGradingService.markAsShow(teacher, peerGrading)


### PR DESCRIPTION
#178 

# Result 

Teacher can see the content of an evaluation that have been hidden 

![DEMO-Hidden-Content](https://github.com/elaastic/elaastic-questions-server/assets/75416431/a4f5d468-7cf4-4f7d-8ea9-da7377cb378b)

The mean grade of an explanation is compute only with the visible peer grading

| Before, the two evaluation are visible | After, one of the two evalution is hidden |
|-------|-------|
| ![image](https://github.com/elaastic/elaastic-questions-server/assets/75416431/18acaa38-34f9-4227-b4dc-9413adc9d30f) | ![image](https://github.com/elaastic/elaastic-questions-server/assets/75416431/06ec7e4f-3eef-4a5e-9213-92ab23b16a7b) |
| ![image](https://github.com/elaastic/elaastic-questions-server/assets/75416431/c4366ea8-d794-45c2-a4d6-abedc90a20dc) | ![image](https://github.com/elaastic/elaastic-questions-server/assets/75416431/b984911a-788d-4336-8931-65cf3a13f7c9) <br> (It's the view of the teacher that why we still have the two evaluation "visible") |
