### PR TITLE
Fix/249 cant see chatgpt feedback with likert

### DIFF
--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/chatGptEvaluation/ChatGptEvaluationController.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/chatGptEvaluation/ChatGptEvaluationController.kt
@@ -1,13 +1,22 @@
 package org.elaastic.questions.assignment.sequence.interaction.chatGptEvaluation
 
+import org.elaastic.questions.assignment.AssignmentService
+import org.elaastic.questions.assignment.sequence.interaction.response.ResponseService
+import org.elaastic.questions.assignment.sequence.peergrading.PeerGradingService
 import org.elaastic.questions.assignment.sequence.peergrading.draxo.DraxoPeerGradingController.ResponseSubmissionAsynchronous
 import org.elaastic.questions.directory.User
+import org.elaastic.questions.player.components.evaluation.EvaluationModel
+import org.elaastic.questions.player.components.evaluation.chatGptEvaluation.ChatGptEvaluationModelFactory
+import org.elaastic.questions.util.requireAccess
+import org.elaastic.questions.util.requireAccessThrowDenied
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
+import org.springframework.ui.set
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
@@ -16,6 +25,9 @@ import java.util.*
 class ChatGptEvaluationController(
     @Autowired val chatGptEvaluationService: ChatGptEvaluationService,
     @Autowired val messageSource: MessageSource,
+    @Autowired val responseService: ResponseService,
+    @Autowired val assignmentService: AssignmentService,
+    @Autowired val peerGradingService: PeerGradingService,
 ) {
 
     @ResponseBody
@@ -88,5 +100,55 @@ class ChatGptEvaluationController(
                 content = messageSource.getMessage("evaluation.unhideEvaluation.error.content", null, locale)
             )
         }
+    }
+
+    @ResponseBody
+    @GetMapping("/{responseId}")
+    fun getChatGptEvaluation(
+        authentication: Authentication,
+        model: Model,
+        @PathVariable responseId: Long,
+    ): String {
+        val user: User = authentication.principal as User
+
+        val response = responseService.findById(responseId)
+        val assignment = response.interaction.sequence.assignment
+
+        // Check authorizations
+        requireAccessThrowDenied(
+            assignment?.owner == user
+                    || (assignment != null
+                    && assignmentService.userIsRegisteredInAssignment(user, assignment))
+        ) {
+            "You are not authorized to access to these feedback"
+        }
+
+        val chatGptEvaluation = chatGptEvaluationService.findEvaluationByResponse(response)
+        val chatGptEvaluationModel =
+            // If it isn't the teacher, we check if the teacher has hidden the chatGPT evaluation.
+            // Eq. If it's a student, we check if the teacher has hidden the chatGPT evaluation.
+            // If it's hidden, we give a null value to the model.
+            if (response.interaction.sequence.chatGptEvaluationEnabled && !(user != assignment!!.owner && chatGptEvaluation?.hiddenByTeacher == true)) {
+                // If the ChatGPT evaluation is enabled, we add it to the model
+                ChatGptEvaluationModelFactory.build(
+                    evaluation = chatGptEvaluation,
+                    sequence = response.interaction.sequence,
+                    canHideGrading = responseService.canHidePeerGrading(user, response),
+                    responseId = response.id
+                )
+            } else null
+
+        val evaluationModel = EvaluationModel(
+            null,
+            chatGptEvaluationModel,
+            false,
+            canSeeChatGPTEvaluation = user == assignment!!.owner || user == response.learner, // Only the teacher and the learner of the question can see the chatGPT evaluation
+            isTeacher = user == assignment.owner
+        )
+
+        model["user"] = user
+        model["evaluationModel"] = evaluationModel
+
+        return "player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show-list::draxoShowList"
     }
 }

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/chatGptEvaluation/ChatGptEvaluationService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/chatGptEvaluation/ChatGptEvaluationService.kt
@@ -74,13 +74,8 @@ class ChatGptEvaluationService(
 
     }
 
-    fun findEvaluationByResponse(response: Response?): ChatGptEvaluation? {
-        // TODO Review JT : Code smell ==> How comes one can ask for findEvaluationByResponse(null) ?
-        if (response == null) {
-            return null
-        }
-        return chatGptEvaluationRepository.findByResponse(response)
-    }
+    fun findEvaluationByResponse(response: Response): ChatGptEvaluation? =
+        chatGptEvaluationRepository.findByResponse(response)
 
     fun findEvaluationById(id: Long): ChatGptEvaluation? {
         return chatGptEvaluationRepository.findById(id).get()

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/chatGptEvaluation/ChatGptEvaluationService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/chatGptEvaluation/ChatGptEvaluationService.kt
@@ -29,15 +29,19 @@ class ChatGptEvaluationService(
 
     @Async
     @Transactional(propagation = Propagation.NEVER)
-    fun createEvaluation(response: Response, language: String, chatGptExistingEvaluation : ChatGptEvaluation? = null): ChatGptEvaluation {
+    fun createEvaluation(
+        response: Response,
+        language: String,
+        chatGptExistingEvaluation: ChatGptEvaluation? = null
+    ): ChatGptEvaluation {
 
         val title = response.statement.title
         val questionContent = response.statement.content
         val teacherExplanation = response.statement.expectedExplanation
         val studentExplanation = response.explanation
 
-        requireNotNull(teacherExplanation){ throw IllegalArgumentException("Error: You must define an expected explanation to create a ChatGPT evaluation") }
-        requireNotNull(studentExplanation){ throw IllegalArgumentException("Error: No explanation to evaluate") }
+        requireNotNull(teacherExplanation) { throw IllegalArgumentException("Error: You must define an expected explanation to create a ChatGPT evaluation") }
+        requireNotNull(studentExplanation) { throw IllegalArgumentException("Error: No explanation to evaluate") }
 
         val chatGptEvaluation = chatGptExistingEvaluation ?: ChatGptEvaluation(response = response)
         markEvaluationAsPending(chatGptEvaluation)
@@ -101,74 +105,102 @@ class ChatGptEvaluationService(
     }
 
     /**
-     *  Update the utility grade associated with a chatGPT evaluation.
+     * Update the utility grade associated with a chatGPT evaluation.
      *
-     *  @param chatGptEvaluation the chatGPT evaluation to update.
-     *  @param utilityGrade the utility grade.
+     * @param chatGptEvaluation the chatGPT evaluation to update.
+     * @param utilityGrade the utility grade.
      */
     fun changeUtilityGrade(chatGptEvaluation: ChatGptEvaluation, utilityGrade: UtilityGrade) {
         reportCandidateService.updateGrade(chatGptEvaluation, utilityGrade, chatGptEvaluationRepository)
     }
 
     /**
-     *  Update the report associated with a chatGPT evaluation.
+     * Update the report associated with a chatGPT evaluation.
      *
-     *  @param chatGptEvaluation the chatGPT evaluation to update.
-     *  @param reportReasons the reasons for the report.
-     *  @param reportComment the comment for the report.
+     * @param chatGptEvaluation the chatGPT evaluation to update.
+     * @param reportReasons the reasons for the report.
+     * @param reportComment the comment for the report.
      */
-    fun reportEvaluation(chatGptEvaluation: ChatGptEvaluation, reportReasons: List<String>, reportComment : String? = null) {
-        reportCandidateService.updateReport(chatGptEvaluation, reportReasons, reportComment, chatGptEvaluationRepository)
+    fun reportEvaluation(
+        chatGptEvaluation: ChatGptEvaluation,
+        reportReasons: List<String>,
+        reportComment: String? = null
+    ) {
+        reportCandidateService.updateReport(
+            chatGptEvaluation,
+            reportReasons,
+            reportComment,
+            chatGptEvaluationRepository
+        )
     }
 
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    fun markEvaluationAsPending(chatGptEvaluation: ChatGptEvaluation) : ChatGptEvaluation {
+    fun markEvaluationAsPending(chatGptEvaluation: ChatGptEvaluation): ChatGptEvaluation {
         chatGptEvaluation.status = ChatGptEvaluationStatus.PENDING.name
         return chatGptEvaluationRepository.saveAndFlush(chatGptEvaluation)
     }
 
     /**
-     * Check if the visibility of a chatGPT evaluation can be changed by the given user
+     * Check if the visibility of a chatGPT evaluation can be changed by the
+     * given user
      *
-     * A user can hide a chatGPT evaluation if the user is the teacher of the sequence and if the evaluation is done.
+     * A user can hide a chatGPT evaluation if the user is the teacher of the
+     * sequence and if the evaluation is done.
      *
      * @param chatGptEvaluation the chatGPT evaluation to check.
-     * @param user the user who wants to update the visibility of the evaluation.
-     * @return true if the visibility of the chatGPT evaluation can be changed, false otherwise.
+     * @param user the user who wants to update the visibility of the
+     *     evaluation.
+     * @return true if the visibility of the chatGPT evaluation can be changed,
+     *     false otherwise.
      */
     fun canUpdateVisibilityEvaluation(chatGptEvaluation: ChatGptEvaluation, user: User): Boolean {
-        return responseService.canHidePeerGrading(user, chatGptEvaluation.response) && chatGptEvaluation.status == ChatGptEvaluationStatus.DONE.name
+        return responseService.canHidePeerGrading(
+            user,
+            chatGptEvaluation.response
+        ) && chatGptEvaluation.status == ChatGptEvaluationStatus.DONE.name
     }
 
     /**
      * Hide a chatGPT evaluation.
      *
-     * An user must have the permission to hide the evaluation.
-     * If the user doesn't have the permission, an exception is thrown.
+     * An user must have the permission to hide the evaluation. If the user
+     * doesn't have the permission, an exception is thrown.
      *
      * @param chatGptEvaluation the chatGPT evaluation to hide.
      * @param user the user who wants to hide the evaluation.
-     * @throws IllegalAccessException if the user doesn't have the permission to hide the evaluation.
+     * @throws IllegalAccessException if the user doesn't have the permission
+     *     to hide the evaluation.
      */
     @Throws(IllegalAccessException::class)
     fun markAsHidden(chatGptEvaluation: ChatGptEvaluation, user: User) {
-        requireAccess(canUpdateVisibilityEvaluation(chatGptEvaluation, user)) {"You don't have the permission to hide this evaluation"}
+        requireAccess(
+            canUpdateVisibilityEvaluation(
+                chatGptEvaluation,
+                user
+            )
+        ) { "You don't have the permission to hide this evaluation" }
         reportCandidateService.markAsHidden(chatGptEvaluation, chatGptEvaluationRepository)
     }
 
     /**
      * Unhide a chatGPT evaluation.
      *
-     * An user must have the permission to unhide the evaluation.
-     * If the user doesn't have the permission, an exception is thrown.
+     * An user must have the permission to unhide the evaluation. If the user
+     * doesn't have the permission, an exception is thrown.
      *
-     * @param chatGptEvaluation the chatGPT evaluation to unhide
+     * @param chatGPTEvaluation the chatGPT evaluation to unhide
      * @param user the user who wants to unhide the evaluation.
-     * @throws IllegalAccessException if the user doesn't have the permission to unhide the evaluation.
+     * @throws IllegalAccessException if the user doesn't have the permission
+     *     to unhide the evaluation.
      */
     @Throws(IllegalAccessException::class)
     fun markAsShown(chatGPTEvaluation: ChatGptEvaluation, user: User) {
-        requireAccess(canUpdateVisibilityEvaluation(chatGPTEvaluation, user)) {"You don't have the permission to unhide this evaluation"}
+        requireAccess(
+            canUpdateVisibilityEvaluation(
+                chatGPTEvaluation,
+                user
+            )
+        ) { "You don't have the permission to unhide this evaluation" }
         reportCandidateService.markAsShown(chatGPTEvaluation, chatGptEvaluationRepository)
     }
 }

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
@@ -60,6 +60,23 @@ class ResponseService(
         EntityNotFoundException("There is no response with id='$id'")
     }
 
+    /**
+     * Return the response with the given id. It will return the last attempt
+     * if it's exist
+     *
+     * @param id the id of the response to find
+     * @return the response with the given id, or the last attempt if it exists
+     */
+    fun findByIdLastAttempt(id: Long): Response {
+        val response = findById(id)
+        val secondAttempt = responseRepository.findByInteractionAndAttemptAndLearner(
+            response.interaction,
+            2,
+            response.learner
+        )
+        return secondAttempt ?: response
+    }
+
     fun findAll(sequence: Sequence, excludeFakes: Boolean = true): ResponseSet =
         findAll(sequence.getResponseSubmissionInteraction(), excludeFakes)
 

--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseService.kt
@@ -53,10 +53,10 @@ class ResponseService(
     fun getReferenceById(id: Long) = responseRepository.getReferenceById(id)
 
     /**
-     * It will immediately throw an exception if it does not exists (while getReferenceById will delay the query
-     * and so the eventual exception)
+     * It will immediately throw an exception if it does not exists (while
+     * getReferenceById will delay the query and so the eventual exception)
      */
-    fun findById(id: Long) = responseRepository.findById(id).orElseThrow {
+    fun findById(id: Long): Response = responseRepository.findById(id).orElseThrow {
         EntityNotFoundException("There is no response with id='$id'")
     }
 
@@ -159,8 +159,8 @@ class ResponseService(
 
 
     /**
-     *  Update the mean grade and nb of evaluations for every responses
-     *  bound the provided interaction
+     * Update the mean grade and nb of evaluations for every responses bound
+     * the provided interaction
      */
     fun updateGradings(sequence: Sequence) {
         // TODO Attempt to deactivate this global stat update in favor of micro update a each peer grading deposit ; this code is kept in comment the time to check everything is working properly
@@ -198,9 +198,10 @@ class ResponseService(
         response.evaluationCount = res[0]?.let { (it as Long).toInt() } ?: 0
         response.draxoEvaluationCount = res[1]?.let { (it as Long).toInt() } ?: 0
 
-        val meangrade = entityManager.createQuery("select avg(pg.grade) from PeerGrading pg where pg.response = :response and pg.hiddenByTeacher = false")
-            .setParameter("response", response)
-            .singleResult as Double?
+        val meangrade =
+            entityManager.createQuery("select avg(pg.grade) from PeerGrading pg where pg.response = :response and pg.hiddenByTeacher = false")
+                .setParameter("response", response)
+                .singleResult as Double?
         response.meanGrade = meangrade?.let { BigDecimal(it).setScale(2, RoundingMode.HALF_UP) }
 
         return responseRepository.save(response)
@@ -232,8 +233,9 @@ class ResponseService(
 
     /**
      * Build response from teacher expected explanation
-     * @param teacher the teacher
+     *
      * @param sequence the sequence
+     * @param teacher the teacher
      */
     fun buildResponseBasedOnTeacherExpectedExplanationForASequence(
         sequence: Sequence,
@@ -283,7 +285,8 @@ class ResponseService(
 
 
     /**
-     * Build  responses from teacher fake explanations
+     * Build responses from teacher fake explanations
+     *
      * @param sequence the sequence
      */
     fun buildResponsesBasedOnTeacherFakeExplanationsForASequence(
@@ -330,6 +333,7 @@ class ResponseService(
 
     /**
      * Mark a response as hidden by a teacher
+     *
      * @param response the response to hide
      * @return the response
      */
@@ -352,6 +356,7 @@ class ResponseService(
 
     /**
      * Mark a response as NOT hidden by a teacher
+     *
      * @param response the previously hidden response to show again
      * @return the response
      */
@@ -370,6 +375,7 @@ class ResponseService(
 
     /**
      * Mark a response as recommended by a teacher
+     *
      * @param response the response to add as recommended
      * @return the response
      */
@@ -388,6 +394,7 @@ class ResponseService(
 
     /**
      * Mark a response as NOT recommended by a teacher
+     *
      * @param response the previously recommended response
      * @return the response
      */
@@ -405,8 +412,9 @@ class ResponseService(
     }
 
     /**
-     * Return true if the user can hide the peer grading of a response
-     * An user can hide the peer grading if he is the owner of the assigment
+     * Return true if the user can hide the peer grading of a response An user
+     * can hide the peer grading if he is the owner of the assigment
+     *
      * @param teacher the user who want to hide the peer grading
      * @param response the response where the peer grading to hide is
      * @return true if the user can hide the peer grading
@@ -417,8 +425,9 @@ class ResponseService(
 
 
     /**
-     * Return true if the user can moderate the feedback of the response
-     * An user can moderate the feedback if he is the owner of the sequence
+     * Return true if the user can moderate the feedback of the response An
+     * user can moderate the feedback if he is the owner of the sequence
+     *
      * @param user the user who want to moderate the feedback
      * @param response the response to moderate
      */

--- a/src/main/kotlin/org/elaastic/questions/player/PlayerController.kt
+++ b/src/main/kotlin/org/elaastic/questions/player/PlayerController.kt
@@ -593,21 +593,20 @@ class PlayerController(
         return "redirect:/player/assignment/${sequence.assignment!!.id}/play/sequence/${id}"
     }
 
-    @GetMapping("sequence/{id}/chat-gpt-evaluation")
+    @GetMapping("sequence/{responseId}/chat-gpt-evaluation")
     @PreAuthorize("@featureManager.isActive(@featureResolver.getFeature('CHATGPT_EVALUATION'))")
     fun viewChatGptEvaluation(
         authentication: Authentication,
         model: Model,
-        @PathVariable id: Long
+        @PathVariable responseId: Long
     ): String {
         val user: User = authentication.principal as User
-        val sequence = sequenceService.get(id, true)
 
-        val response = responseService.find(user, sequence, 2) ?: responseService.find(user, sequence, 1)
+        val response = responseService.findById(responseId)
         val chatGptEvaluation = chatGptEvaluationService.findEvaluationByResponse(response)
         model.addAttribute(
             "chatGptEvaluationModel",
-            ChatGptEvaluationModelFactory.build(chatGptEvaluation, sequence, responseId = response?.id)
+            ChatGptEvaluationModelFactory.build(chatGptEvaluation, response.interaction.sequence, responseId = response?.id)
         )
         return "player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-viewer"
     }

--- a/src/main/kotlin/org/elaastic/questions/player/phase/result/LearnerResultPhaseExecutionLoader.kt
+++ b/src/main/kotlin/org/elaastic/questions/player/phase/result/LearnerResultPhaseExecutionLoader.kt
@@ -58,7 +58,9 @@ class LearnerResultPhaseExecutionLoader(
                 )
         }
 
-        val evaluation = chatGptEvaluationService.findEvaluationByResponse(secondResponse ?: firstResponse)
+        // If both responses are null, then the chatGptEvaluation will be null
+        val evaluation =
+            (secondResponse ?: firstResponse)?.let { chatGptEvaluationService.findEvaluationByResponse(it) }
 
         val myChatGptEvaluationModel = if (learnerPhase.learnerSequence.sequence.chatGptEvaluationEnabled) {
             ChatGptEvaluationModelFactory.build(evaluation, learnerPhase.learnerSequence.sequence)

--- a/src/main/kotlin/org/elaastic/questions/test/FunctionalTestingService.kt
+++ b/src/main/kotlin/org/elaastic/questions/test/FunctionalTestingService.kt
@@ -176,7 +176,7 @@ class FunctionalTestingService(
         correct: Boolean,
         confidenceDegree: ConfidenceDegree,
         explanation: String? = null
-    ) {
+    ): Response {
         registerUserIfNeeded(user, sequence)
 
         // Check preconditions depending on phase
@@ -212,7 +212,7 @@ class FunctionalTestingService(
             }
         }
 
-        sequenceService.submitResponse(
+        return sequenceService.submitResponse(
             user,
             sequence,
             PlayerController.ResponseSubmissionData(

--- a/src/main/kotlin/org/elaastic/questions/util/AccessUtil.kt
+++ b/src/main/kotlin/org/elaastic/questions/util/AccessUtil.kt
@@ -1,8 +1,26 @@
 package org.elaastic.questions.util
 
+import org.springframework.security.access.AccessDeniedException
+import kotlin.jvm.Throws
+
+/**
+ * Throws an [IllegalAccessException] if the condition is false.
+ */
+@Throws(IllegalAccessException::class)
 inline fun requireAccess(condition: Boolean, lazyMessage: () -> Any) {
     if (!condition) {
         val message = lazyMessage()
         throw IllegalAccessException(message.toString())
+    }
+}
+
+/**
+ * Throws an [AccessDeniedException] if the condition is false.
+ */
+@Throws(AccessDeniedException::class)
+inline fun requireAccessThrowDenied(condition: Boolean, lazyMessage: () -> Any) {
+    if (!condition) {
+        val message = lazyMessage()
+        throw AccessDeniedException(message.toString())
     }
 }

--- a/src/main/resources/static/js/elaastic/draxo/draxo-fn.js
+++ b/src/main/resources/static/js/elaastic/draxo/draxo-fn.js
@@ -22,11 +22,12 @@
 var elaastic = elaastic || {};
 
 (function () {
-    let baseUrl = ''
+    let draxoBaseUrl = ''
+    let chatGPTBaseUrl = ''
 
     elaastic.draxo = {
         initialize(url) {
-            baseUrl = url
+            draxoBaseUrl = url
         },
 
         loadReviews(event, responseId) {
@@ -56,7 +57,57 @@ var elaastic = elaastic || {};
                 }
 
                 $.ajax({
-                    url: baseUrl + '/' + responseId,
+                    url: draxoBaseUrl + '/' + responseId,
+                    method: 'GET',
+                    data,
+                    success: function (data) {
+                        const targetElm = $(target)
+                        const availableWidth = targetElm.width()
+
+                        targetElm.html(data)
+                        if (availableWidth < 900) {
+                            $('.ui.mini.steps').addClass('vertical')
+                        }
+                    },
+                    error: function (error) {
+                        let errorMessage = error.responseJSON ? error.responseJSON.error : error.responseText
+                        $(target).html(buildHtmlError(errorMessage))
+                    }
+                })
+            }
+        }
+    }
+
+    elaastic.chatGPT = {
+        initialize(url) {
+            chatGPTBaseUrl = url
+        },
+
+        loadReview(event, responseId) {
+            event.preventDefault()
+
+            let elmBtnLoadReviews = event.target
+            let target = findElmReviewsContainer(
+                findElmExplanationContainer(elmBtnLoadReviews)
+            )
+
+            if ($(target).html().length > 0) {
+                // The reviews are already loaded
+                if ($(target).is(':visible')) {
+                    // The reviews are visible
+                    $(target).slideUp();
+                } else {
+                    // The reviews are hidden
+                    $(target).slideDown();
+                }
+            } else {
+                // The reviews are not loaded
+                $(target).html(buildHtmlLoader())
+
+                let data = {}
+
+                $.ajax({
+                    url: chatGPTBaseUrl + '/' + responseId,
                     method: 'GET',
                     data,
                     success: function (data) {

--- a/src/main/resources/static/js/elaastic/draxo/draxo-fn.js
+++ b/src/main/resources/static/js/elaastic/draxo/draxo-fn.js
@@ -32,18 +32,31 @@ var elaastic = elaastic || {};
         loadReviews(event, responseId) {
             event.preventDefault()
 
-            let elmBtnLoadReviews = event.target
+            let elmBtnLoadReviews = event.target.parentNode
             let target = findElmReviewsContainer(
                 findElmExplanationContainer(elmBtnLoadReviews)
             )
 
+            console.log(event.target)
+
+            const hideReviewLink = $(elmBtnLoadReviews).find('.hide-review')
+            const seeReviewLink = $(elmBtnLoadReviews).find('.see-review')
+
+            if (hideReviewLink.is(':visible')) {
+                hideReviewLink.hide()
+                seeReviewLink.show()
+            } else {
+                hideReviewLink.show()
+                seeReviewLink.hide()
+            }
+
             if ($(target).html().length > 0) {
                 // The reviews are already loaded
                 if ($(target).is(':visible')) {
-                    // The reviews are visible
+                    // The reviews are visible -> hide them
                     $(target).slideUp();
                 } else {
-                    // The reviews are hidden
+                    // The reviews are hidden -> show them
                     $(target).slideDown();
                 }
             } else {
@@ -81,18 +94,30 @@ var elaastic = elaastic || {};
         loadReview(event, responseId) {
             event.preventDefault()
 
-            let elmBtnLoadReviews = event.target
+            let elmBtnLoadReviews = event.target.parentNode
             let target = findElmReviewsContainer(
                 findElmExplanationContainer(elmBtnLoadReviews)
             )
+            console.log(event.target)
+
+            const hideReviewLink = $(elmBtnLoadReviews).find('.hide-review')
+            const seeReviewLink = $(elmBtnLoadReviews).find('.see-review')
+
+            if (hideReviewLink.is(':visible')) {
+                hideReviewLink.hide()
+                seeReviewLink.show()
+            } else {
+                hideReviewLink.show()
+                seeReviewLink.hide()
+            }
 
             if ($(target).html().length > 0) {
                 // The reviews are already loaded
                 if ($(target).is(':visible')) {
-                    // The reviews are visible
+                    // The reviews are visible -> hide them
                     $(target).slideUp();
                 } else {
-                    // The reviews are hidden
+                    // The reviews are hidden -> show them
                     $(target).slideDown();
                 }
             } else {

--- a/src/main/resources/static/js/elaastic/draxo/draxo-fn.js
+++ b/src/main/resources/static/js/elaastic/draxo/draxo-fn.js
@@ -23,7 +23,6 @@ var elaastic = elaastic || {};
 
 (function () {
     let draxoBaseUrl = ''
-    let chatGPTBaseUrl = ''
 
     elaastic.draxo = {
         initialize(url) {
@@ -79,10 +78,6 @@ var elaastic = elaastic || {};
     }
 
     elaastic.chatGPT = {
-        initialize(url) {
-            chatGPTBaseUrl = url
-        },
-
         loadReview(event, responseId) {
             event.preventDefault()
 
@@ -107,7 +102,7 @@ var elaastic = elaastic || {};
                 let data = {}
 
                 $.ajax({
-                    url: chatGPTBaseUrl + '/' + responseId,
+                    url: '/chatGptEvaluation/' + responseId,
                     method: 'GET',
                     data,
                     success: function (data) {

--- a/src/main/resources/templates/i18n/draxo.properties
+++ b/src/main/resources/templates/i18n/draxo.properties
@@ -19,5 +19,8 @@ draxo.value.noOpinion=I have no opinion
 draxo.help.title=More information on the DRAXO evaluation grid
 draxo.evaluationGrid=Evaluation grid
 draxo.feedback.label=Feedback:
+
 draxo.see.reviews=see reviews
 draxo.see.review=see the review
+draxo.hide.reviews=hide reviews
+draxo.hide.review=hide the review

--- a/src/main/resources/templates/i18n/draxo_en.properties
+++ b/src/main/resources/templates/i18n/draxo_en.properties
@@ -19,5 +19,8 @@ draxo.value.noOpinion=I have no opinion
 draxo.help.title=More information on the DRAXO evaluation grid
 draxo.evaluationGrid=Evaluation grid
 draxo.feedback.label=Feedback:
+
 draxo.see.reviews=see reviews
 draxo.see.review=see the review
+draxo.hide.reviews=hide reviews
+draxo.hide.review=hide the review

--- a/src/main/resources/templates/i18n/draxo_fr.properties
+++ b/src/main/resources/templates/i18n/draxo_fr.properties
@@ -24,5 +24,8 @@ draxo.value.noOpinion=Je ne me prononce pas
 draxo.help.title=Plus d'informations sur la grille d'évaluation DRAXO
 draxo.evaluationGrid=Grille d'évaluation
 draxo.feedback.label=Commentaire :
+
 draxo.see.reviews=voir les évaluations
 draxo.see.review=voir l'évaluation
+draxo.hide.reviews=masquer les évaluations
+draxo.hide.review=masquer l'évaluation

--- a/src/main/resources/templates/i18n/evaluation.properties
+++ b/src/main/resources/templates/i18n/evaluation.properties
@@ -35,3 +35,4 @@ evaluation.unhideEvaluation.error.header=Unhiding failed
 evaluation.unhideEvaluation.error.content=An error occurred when the evaluation was unhidden.
 
 evaluation.see.chatGPT.review=See ChatGPT review
+evaluation.hide.chatGPT.review=Hide ChatGPT review

--- a/src/main/resources/templates/i18n/evaluation.properties
+++ b/src/main/resources/templates/i18n/evaluation.properties
@@ -33,3 +33,5 @@ evaluation.unhideEvaluation.success.content=The evaluation was successfully redi
 evaluation.unhideEvaluation.accesDenied.content=You do not have the right to redisplay this evalaution.
 evaluation.unhideEvaluation.error.header=Unhiding failed
 evaluation.unhideEvaluation.error.content=An error occurred when the evaluation was unhidden.
+
+evaluation.see.chatGPT.review=See ChatGPT review

--- a/src/main/resources/templates/i18n/evaluation_en.properties
+++ b/src/main/resources/templates/i18n/evaluation_en.properties
@@ -35,3 +35,4 @@ evaluation.unhideEvaluation.error.header=Unhiding failed
 evaluation.unhideEvaluation.error.content=An error occurred when the evaluation was unhidden.
 
 evaluation.see.chatGPT.review=See ChatGPT review
+evaluation.hide.chatGPT.review=Hide ChatGPT review

--- a/src/main/resources/templates/i18n/evaluation_en.properties
+++ b/src/main/resources/templates/i18n/evaluation_en.properties
@@ -33,3 +33,5 @@ evaluation.unhideEvaluation.success.content=The evaluation was successfully redi
 evaluation.unhideEvaluation.accesDenied.content=You do not have the right to redisplay this evalaution.
 evaluation.unhideEvaluation.error.header=Unhiding failed
 evaluation.unhideEvaluation.error.content=An error occurred when the evaluation was unhidden.
+
+evaluation.see.chatGPT.review=See ChatGPT review

--- a/src/main/resources/templates/i18n/evaluation_fr.properties
+++ b/src/main/resources/templates/i18n/evaluation_fr.properties
@@ -33,3 +33,5 @@ evaluation.unhideEvaluation.success.content=L'évaluation a été réaffichée a
 evaluation.unhideEvaluation.accesDenied.content=Vous n'avez pas les droits pour réafficher cette évaluation.
 evaluation.unhideEvaluation.error.header=Echec du réaffichage
 evaluation.unhideEvaluation.error.content=Une erreur s'est produite lors du réaffichage de l'évaluation.
+
+evaluation.see.chatGPT.review=Voir l'évaluation de ChatGPT

--- a/src/main/resources/templates/i18n/evaluation_fr.properties
+++ b/src/main/resources/templates/i18n/evaluation_fr.properties
@@ -35,3 +35,4 @@ evaluation.unhideEvaluation.error.header=Echec du réaffichage
 evaluation.unhideEvaluation.error.content=Une erreur s'est produite lors du réaffichage de l'évaluation.
 
 evaluation.see.chatGPT.review=Voir l'évaluation de ChatGPT
+evaluation.hide.chatGPT.review=Masquer l'évaluation de ChatGPT

--- a/src/main/resources/templates/layout/3columns.html
+++ b/src/main/resources/templates/layout/3columns.html
@@ -45,6 +45,9 @@
     <script th:inline="javascript">
       elaastic.draxo.initialize(/*[[@{/peer-grading/draxo}]]*/);
     </script>
+    <script th:inline="javascript">
+      elaastic.chatGPT.initialize(/*[[@{/peer-grading/draxo}]]*/);
+    </script>
     <script th:src="@{/js/intro.min.js}"></script>
     <script th:src="@{/js/onboarding.js}"></script>
     <meta th:replace="${extraHeader}"/>
@@ -94,7 +97,7 @@
          data-inverted="">
         <i class="folder open icon"></i>
       </a>
-      
+
       <a sec:authorize="hasAnyAuthority('TEACHER_ROLE', 'ADMIN_ROLE')"
          th:href="@{/subject}"
          href="/subjects"

--- a/src/main/resources/templates/layout/3columns.html
+++ b/src/main/resources/templates/layout/3columns.html
@@ -45,9 +45,6 @@
     <script th:inline="javascript">
       elaastic.draxo.initialize(/*[[@{/peer-grading/draxo}]]*/);
     </script>
-    <script th:inline="javascript">
-      elaastic.chatGPT.initialize(/*[[@{/peer-grading/draxo}]]*/);
-    </script>
     <script th:src="@{/js/intro.min.js}"></script>
     <script th:src="@{/js/onboarding.js}"></script>
     <meta th:replace="${extraHeader}"/>

--- a/src/main/resources/templates/layout/leftMenu.html
+++ b/src/main/resources/templates/layout/leftMenu.html
@@ -45,6 +45,9 @@
   <script th:inline="javascript">
     elaastic.draxo.initialize(/*[[@{/peer-grading/draxo}]]*/);
   </script>
+  <script th:inline="javascript">
+    elaastic.chatGPT.initialize(/*[[@{/peer-grading/draxo}]]*/);
+  </script>
   <script th:src="@{/js/onboarding.js}"></script>
   <meta th:replace="${extraHeader}"/>
 

--- a/src/main/resources/templates/layout/leftMenu.html
+++ b/src/main/resources/templates/layout/leftMenu.html
@@ -45,9 +45,6 @@
   <script th:inline="javascript">
     elaastic.draxo.initialize(/*[[@{/peer-grading/draxo}]]*/);
   </script>
-  <script th:inline="javascript">
-    elaastic.chatGPT.initialize(/*[[@{/peer-grading/draxo}]]*/);
-  </script>
   <script th:src="@{/js/onboarding.js}"></script>
   <meta th:replace="${extraHeader}"/>
 

--- a/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-viewer.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-viewer.html
@@ -112,7 +112,7 @@
     <script th:inline="javascript">
         function refreshFragment() {
             $.ajax({
-                url: '/player/sequence/' + [[${chatGptEvaluationModel.sequenceId}]] + '/chat-gpt-evaluation',
+                url: '/player/sequence/' + [[${chatGptEvaluationModel.responseId}]] + '/chat-gpt-evaluation',
                 type: "GET",
                 success: function (data) {
                     var chatGptEvaluationFragment = data.replace( /<!--[\s\S]*?-->/, '');

--- a/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
@@ -38,13 +38,13 @@
               th:text="${explanation.getNbEvaluation(isTeacher)}+' '+#{common.evaluations}"></span>
 
         <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) > 0}">
-        (<a class="detail-link" href="#"
+        (<a class="detail-link" id="loadReview" href="#"
             th:onclick="'elaastic.draxo.loadReviews(event, ' + ${explanation.responseId}+')'"
             th:text="${(explanation.getNbEvaluation(isTeacher) > 1)} ? #{draxo.see.reviews} : #{draxo.see.review}">see reviews</a> )
         </span>
 
         <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) == 0 && (isOwner || isTeacher)}">
-        (<a class="detail-link" href="#"
+        (<a class="detail-link" id="loadReview" href="#"
             th:onclick="'elaastic.chatGPT.loadReview(event, ' + ${explanation.responseId}+')'"
             th:text="#{evaluation.see.chatGPT.review}">see ChatGPT review</a> )
         </span>

--- a/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
@@ -68,35 +68,42 @@
                 <!-- If explanation is in recommended -->
                 <a th:classappend="'removeRecommendation-' + ${explanation.responseId}"
                    th:onclick="removeRecommendation([[${explanation.responseId}]])"
-                   type="button" data-position="bottom right" th:data-tooltip="#{player.sequence.explanation.removeRecommended}" class="ui button" style="padding: 0.5rem; margin-right: 0;">
+                   type="button" data-position="bottom right"
+                   th:data-tooltip="#{player.sequence.explanation.removeRecommended}" class="ui button"
+                   style="padding: 0.5rem; margin-right: 0;">
                     <i class="star icon"></i>
                 </a>
 
                 <!-- If explanation is not in recommended -->
                 <a th:classappend="'addRecommendation-' + ${explanation.responseId}"
                    th:onclick="addRecommendation([[${explanation.responseId}]])"
-                   type="button" data-position="bottom right" th:data-tooltip="#{player.sequence.explanation.addRecommended}" class="ui button" style="padding: 0.5rem; margin-right: 0;">
+                   type="button" data-position="bottom right"
+                   th:data-tooltip="#{player.sequence.explanation.addRecommended}" class="ui button"
+                   style="padding: 0.5rem; margin-right: 0;">
                     <i class="empty star icon"></i>
                 </a>
             </div>
 
             <!-- If explanation is not hidden -->
-            <a  th:if="${!explanation.hiddenByTeacher}"
-                    th:href="@{/player/response/{responseId}/hide-response(responseId=${explanation.responseId})}"
-                    type="button" data-position="bottom right" th:data-tooltip="#{player.sequence.explanation.hideResponse}" class="ui button" style="padding: 0.5rem; margin-right: 0;">
+            <a th:if="${!explanation.hiddenByTeacher}"
+               th:href="@{/player/response/{responseId}/hide-response(responseId=${explanation.responseId})}"
+               type="button" data-position="bottom right" th:data-tooltip="#{player.sequence.explanation.hideResponse}"
+               class="ui button" style="padding: 0.5rem; margin-right: 0;">
                 <i class="unhide icon"></i>
             </a>
 
             <!-- If explanation is hidden -->
-            <a  th:if="${explanation.hiddenByTeacher}"
-                th:href="@{/player/response/{responseId}/unhide-response(responseId=${explanation.responseId})}"
-                type="button" data-position="bottom right" th:data-tooltip="#{player.sequence.explanation.showResponse}" class="ui button" style="padding: 0.5rem; margin-right: 0;">
+            <a th:if="${explanation.hiddenByTeacher}"
+               th:href="@{/player/response/{responseId}/unhide-response(responseId=${explanation.responseId})}"
+               type="button" data-position="bottom right" th:data-tooltip="#{player.sequence.explanation.showResponse}"
+               class="ui button" style="padding: 0.5rem; margin-right: 0;">
                 <i class="hide icon"></i>
             </a>
         </div>
-    </div >
+    </div>
 
-    <div th:if="${explanation.getNbEvaluation(isTeacher) == 0 && explanation.fromTeacher}" class="ui top left attached label green">
+    <div th:if="${explanation.getNbEvaluation(isTeacher) == 0 && explanation.fromTeacher}"
+         class="ui top left attached label green">
         <i class="graduation cap icon" style="margin-right: 0.4em;"></i>
         <span th:text="#{player.sequence.explanation.teacher.label}"></span>
     </div>
@@ -118,10 +125,10 @@
     <div class="reviews-container"></div>
     <script th:inline="javascript">
 
-        var toReload = false;
+        let toReload = false;
 
-        $(document).ready(function() {
-            setupRecommendedByTeacher([[${explanation.responseId}]],[[${explanation.recommendedByTeacher}]])
+        $(document).ready(function () {
+            setupRecommendedByTeacher([[${explanation.responseId}]], [[${explanation.recommendedByTeacher}]])
         });
 
         function setupRecommendedByTeacher(responseId, recommendedByTeacher) {
@@ -131,6 +138,7 @@
                 $('.removeRecommendation-' + responseId).hide()
             }
         }
+
         function removeRecommendation(responseId) {
             toReload = true
             $.ajax({
@@ -138,9 +146,9 @@
                 url: '/player/response/' + responseId + '/remove-recommended-by-teacher',
                 success: () => {
                     $('.removeRecommendation-' + responseId).hide()
-                    $('.addRecommendation-' + + responseId).show()
+                    $('.addRecommendation-' + +responseId).show()
                 },
-                error: function(error) {
+                error: function (error) {
                     // Handle error
                     console.error(error);
                 }
@@ -156,7 +164,7 @@
                     $('.addRecommendation-' + responseId).hide()
                     $(".removeRecommendation-" + responseId).show()
                 },
-                error: function(error) {
+                error: function (error) {
                     // Handle error
                     console.error(error);
                 }

--- a/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
@@ -43,7 +43,7 @@
             th:text="${(explanation.getNbEvaluation(isTeacher) > 1)} ? #{draxo.see.reviews} : #{draxo.see.review}">see reviews</a> )
         </span>
 
-        <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) == 0}">
+        <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) == 0 && (isOwner || isTeacher)}">
         (<a class="detail-link" href="#"
             th:onclick="'elaastic.chatGPT.loadReview(event, ' + ${explanation.responseId}+')'"
             th:text="#{evaluation.see.chatGPT.review}">see ChatGPT review</a> )

--- a/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
@@ -39,14 +39,20 @@
 
         <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) > 0}">
         (<a class="detail-link" id="loadReview" href="#"
-            th:onclick="'elaastic.draxo.loadReviews(event, ' + ${explanation.responseId}+')'"
-            th:text="${(explanation.getNbEvaluation(isTeacher) > 1)} ? #{draxo.see.reviews} : #{draxo.see.review}">see reviews</a> )
+            th:onclick="'elaastic.draxo.loadReviews(event, ' + ${explanation.responseId}+')'">
+            <span th:text="${(explanation.getNbEvaluation(isTeacher) > 1)} ? #{draxo.see.reviews} : #{draxo.see.review}"
+                  class="see-review">see reviews</span>
+            <span th:text="${(explanation.getNbEvaluation(isTeacher) > 1)} ? #{draxo.hide.reviews} : #{draxo.hide.review}"
+                  class="hide-review" style="display: none">see reviews</span>
+        </a> )
         </span>
 
         <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) == 0 && (isOwner || isTeacher)}">
         (<a class="detail-link" id="loadReview" href="#"
-            th:onclick="'elaastic.chatGPT.loadReview(event, ' + ${explanation.responseId}+')'"
-            th:text="#{evaluation.see.chatGPT.review}">see ChatGPT review</a> )
+            th:onclick="'elaastic.chatGPT.loadReview(event, ' + ${explanation.responseId}+')'">
+            <span th:text="#{evaluation.see.chatGPT.review}" class="see-review">see ChatGPT review</span>
+            <span th:text="#{evaluation.hide.chatGPT.review}" class="hide-review" style="display: none">see ChatGPT review</span>
+            </a> )
         </span>
 
         <span th:if="${explanation.hiddenByTeacher}">

--- a/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
@@ -128,7 +128,7 @@
     </div>
     <span th:if="${!explanation.hiddenByTeacher or isOwner}" th:utext="${explanation.content}"></span>
 
-    <div class="reviews-container"></div>
+    <div class="reviews-container" style="margin-top: 20px"></div>
     <script th:inline="javascript">
 
         let toReload = false;

--- a/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
@@ -22,7 +22,8 @@
      th:classappend="|${explanation.fromTeacher ? 'success' : ''} ${explanation.hiddenByTeacher ? 'disabled' : 'info'}|"
      th:styleappend="${explanation.getNbEvaluation(isTeacher) > 0 || explanation.fromTeacher || (isOwner && explanation.hiddenByTeacher) ? 'padding-top: 3em; overflow: unset' : 'overflow: unset'}"
      th:attr="data-response-id=${explanation.responseId}"
-     xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+     xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html"
+     xmlns:togglz="https://github.com/heneke/thymeleaf-extras-togglz">
     <div th:if="${explanation.getNbEvaluation(isTeacher) > 0}" class="ui top left attached label"
          th:classappend="|${explanation.fromTeacher ? 'green' : ''} ${explanation.hiddenByTeacher ? 'grey' : 'teal'}|">
 
@@ -47,7 +48,8 @@
         </a> )
         </span>
 
-        <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) == 0 && (isOwner || isTeacher)}">
+        <span togglz:active="'CHATGPT_EVALUATION'"
+              class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) == 0 && (isOwner || isTeacher)}">
         (<a class="detail-link" id="loadReview" href="#"
             th:onclick="'elaastic.chatGPT.loadReview(event, ' + ${explanation.responseId}+')'">
             <span th:text="#{evaluation.see.chatGPT.review}" class="see-review">see ChatGPT review</span>

--- a/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/explanation-viewer/_anExplanation.html
@@ -42,6 +42,13 @@
             th:onclick="'elaastic.draxo.loadReviews(event, ' + ${explanation.responseId}+')'"
             th:text="${(explanation.getNbEvaluation(isTeacher) > 1)} ? #{draxo.see.reviews} : #{draxo.see.review}">see reviews</a> )
         </span>
+
+        <span class="detail" th:if="${explanation.getNbDraxoEvaluation(isTeacher) == 0}">
+        (<a class="detail-link" href="#"
+            th:onclick="'elaastic.chatGPT.loadReview(event, ' + ${explanation.responseId}+')'"
+            th:text="#{evaluation.see.chatGPT.review}">see ChatGPT review</a> )
+        </span>
+
         <span th:if="${explanation.hiddenByTeacher}">
             <i class="exclamation triangle icon" style="margin: 0 0.4em;"></i>
             <span th:text="#{player.sequence.explanation.hiddenExplanation}"></span>

--- a/src/main/resources/templates/player/assignment/sequence/components/my-results/_my-results.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/my-results/_my-results.html
@@ -80,8 +80,10 @@
 
     <script>
         /*<![CDATA[*/
-        $(document).ready(function () {
-            $('#my-results-accordion-[[${resultId}]]').accordion()
+        $(function () {
+            const myResponseContainer = $('#my-results-accordion-[[${resultId}]]');
+            myResponseContainer.accordion()
+            myResponseContainer.find('#loadReview').click()
         })
         /*]]>*/
     </script>

--- a/src/main/resources/templates/player/assignment/sequence/components/my-results/_my-results.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/my-results/_my-results.html
@@ -83,7 +83,7 @@
         $(function () {
             const myResponseContainer = $('#my-results-accordion-[[${resultId}]]');
             myResponseContainer.accordion()
-            myResponseContainer.find('#loadReview').click()
+            myResponseContainer.find('.see-review').click()
         })
         /*]]>*/
     </script>

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show-list.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show-list.html
@@ -22,7 +22,7 @@
     <link rel="stylesheet" type="text/css" th:href="@{'/css/evaluation.css'}"/>
 
     <!--/* Link to the online documentation of the DRAXO evaluation */-->
-    <span style="float: right" th:if="${@environment.getProperty('elaastic.draxo.help.url')}">
+    <span style="float: right" th:if="${@environment.getProperty('elaastic.draxo.help.url') != null && evaluationModel.draxoEvaluationModels != null}">
         <a th:href="${@environment.getProperty('elaastic.draxo.help.url')}" target="_blank">
             <i class="question circle outline ui icon"></i> <span th:text="#{draxo.help.title}">Link to the detailed explanation of the DRAXO grid</span>
         </a>

--- a/src/test/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseServiceIntegrationTest.kt
+++ b/src/test/kotlin/org/elaastic/questions/assignment/sequence/interaction/response/ResponseServiceIntegrationTest.kt
@@ -37,10 +37,12 @@ import org.elaastic.questions.assignment.sequence.peergrading.draxo.option.Optio
 import org.elaastic.questions.directory.UserService
 import org.elaastic.questions.subject.SubjectService
 import org.elaastic.questions.subject.statement.StatementService
+import org.elaastic.questions.test.FunctionalTestingService
 import org.elaastic.questions.test.IntegrationTestingService
 import org.elaastic.questions.test.directive.tGiven
 import org.elaastic.questions.test.directive.tThen
 import org.elaastic.questions.test.directive.tWhen
+import org.elaastic.questions.test.interpreter.command.Phase
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions.*
@@ -67,6 +69,7 @@ internal class ResponseServiceIntegrationTest(
     @Autowired val entityManager: EntityManager,
     @Autowired val subjectService: SubjectService,
     @Autowired val peerGradingService: PeerGradingService,
+    @Autowired val functionalTestingService: FunctionalTestingService,
 ) {
 
     @Test
@@ -868,6 +871,46 @@ internal class ResponseServiceIntegrationTest(
             peerGradingService.markAsShow(teacher, peerGrading)
         }.tThen("The compute mean grade is 2") {
             assertEquals(two, response.meanGrade, "The mean grade is 2")
+        }
+    }
+
+    @Test
+    fun `test of findByIdLastAttempt`() {
+        // Given
+        val learners = integrationTestingService.getNLearners(1).first()
+        val subject = functionalTestingService.createSubject(integrationTestingService.getTestTeacher())
+        functionalTestingService.addQuestion(subject, QuestionType.OpenEnded)
+        val assignement = functionalTestingService.createAssignment(subject)
+        val sequence = assignement.sequences.first()
+
+        lateinit var responseAttenmpt1: Response
+
+        tWhen("we start the sequence") {
+            functionalTestingService.startSequence(sequence, ExecutionContext.FaceToFace)
+        }.tWhen("we submit a response for the learner") {
+            responseAttenmpt1 = functionalTestingService.submitResponse(
+                Phase.PHASE_1,
+                learners,
+                sequence,
+                true,
+                ConfidenceDegree.CONFIDENT,
+                learners.getDisplayName() + " 1",
+            )
+
+        }.tThen("we get the response for the first attempt") {
+            assertEquals(responseAttenmpt1, responseService.findByIdLastAttempt(responseAttenmpt1.id!!))
+        }.tWhen("The student change is response") {
+            functionalTestingService.nextPhase(sequence) // Evaluation Phase
+            functionalTestingService.submitResponse(
+                Phase.PHASE_2,
+                learners,
+                sequence,
+                true,
+                ConfidenceDegree.CONFIDENT,
+                learners.getDisplayName() + " 2",
+            )
+        }.tThen("We get the response for the second attempt with the id of the first attempt") {
+            assertEquals(it, responseService.findByIdLastAttempt(responseAttenmpt1.id!!))
         }
     }
 }

--- a/src/test/kotlin/org/elaastic/questions/test/util/AccessUtilTest.kt
+++ b/src/test/kotlin/org/elaastic/questions/test/util/AccessUtilTest.kt
@@ -1,0 +1,32 @@
+package org.elaastic.questions.test.util
+
+import org.elaastic.questions.util.requireAccess
+import org.elaastic.questions.util.requireAccessThrowDenied
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.*
+import org.springframework.security.access.AccessDeniedException as AccessDeniedExceptionSpring
+
+class AccessUtilTest {
+
+    @Test
+    fun `test of requireAccess`() {
+        assertDoesNotThrow {
+            requireAccess(true) { "This should not throw an exception" }
+        }
+        assertThrows(IllegalAccessException::class.java) {
+            requireAccess(false) { "This should throw an exception" }
+        }
+    }
+
+    @Test
+    fun `test of requireAccessThrowDenied`() {
+        assertDoesNotThrow {
+            requireAccessThrowDenied(true) { "This should not throw an exception" }
+        }
+        // I rename the import to avoid confusion between the two classes (one is from kotlin, the other from spring)
+        assertThrows(AccessDeniedExceptionSpring::class.java) {
+            requireAccessThrowDenied(false) { "This should throw an exception" }
+        }
+    }
+}


### PR DESCRIPTION
#249 

# Result

In a sequence with ChatGPT enabled, and the evaluation method is Likert, the teacher can see all the evaluation made by ChatGPT.
![Teacher-fix-249](https://github.com/elaastic/elaastic-questions-server/assets/75416431/ccacc4e9-e403-4e52-b2a0-562a870f9d83)

A student can only see the evaluation made on his response.
By default, the review container in the my-result section is expanded.
![Student-fix249](https://github.com/elaastic/elaastic-questions-server/assets/75416431/6d61b180-f3e5-416d-9ec1-2437710436d7)

The text of the link change to match the container state.

All this new behavior is also added for the DRAXO review container.