### PR TITLE
Standardisation of evaluation

### DIFF
--- a/src/main/kotlin/org/elaastic/questions/assignment/sequence/SequenceService.kt
+++ b/src/main/kotlin/org/elaastic/questions/assignment/sequence/SequenceService.kt
@@ -43,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
-import java.util.UUID
+import java.util.*
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
 
@@ -80,15 +80,17 @@ class SequenceService(
         } ?: throw EntityNotFoundException("There is no sequence for id \"$id\"")
     }
 
-    fun findPreviousSequence(sequence: Sequence): Sequence?
-        = sequenceRepository.findPreviousSequence(sequence.rank,
-                                                  sequence.assignment!!,
-                                                  PageRequest.of(0, 1)).firstOrNull()
+    fun findPreviousSequence(sequence: Sequence): Sequence? = sequenceRepository.findPreviousSequence(
+        sequence.rank,
+        sequence.assignment!!,
+        PageRequest.of(0, 1)
+    ).firstOrNull()
 
-    fun findNextSequence(sequence: Sequence): Sequence?
-        = sequenceRepository.findNextSequence(sequence.rank,
-                                              sequence.assignment!!,
-                                              PageRequest.of(0, 1)).firstOrNull()
+    fun findNextSequence(sequence: Sequence): Sequence? = sequenceRepository.findNextSequence(
+        sequence.rank,
+        sequence.assignment!!,
+        PageRequest.of(0, 1)
+    ).firstOrNull()
 
     fun findByUuid(uuid: UUID, fetchInteractions: Boolean = false): Sequence {
         return sequenceRepository.findByUuid(uuid)?.let { sequence ->
@@ -235,7 +237,7 @@ class SequenceService(
         user: User,
         sequence: Sequence,
         responseSubmissionData: PlayerController.ResponseSubmissionData
-    ) : Response {
+    ): Response {
         val choiceListSpecification = responseSubmissionData.choiceList?.let {
             LearnerChoice(it)
         }

--- a/src/main/kotlin/org/elaastic/questions/player/phase/result/LearnerResultPhaseExecutionLoader.kt
+++ b/src/main/kotlin/org/elaastic/questions/player/phase/result/LearnerResultPhaseExecutionLoader.kt
@@ -37,13 +37,13 @@ class LearnerResultPhaseExecutionLoader(
 
         val longBooleanMap = chatGptEvaluationService.associateResponseToChatGPTEvaluationExistence(
             listOf(
-                firstResponse!!.id,
-                secondResponse!!.id
+                firstResponse?.id,
+                secondResponse?.id
             )
         )
 
-        val responseFirstTryHasChatGPTEvaluation: Boolean = longBooleanMap[firstResponse.id] == true
-        val responseSecondTryHasChatGPTEvaluation: Boolean = longBooleanMap[secondResponse.id] == true
+        val responseFirstTryHasChatGPTEvaluation: Boolean = longBooleanMap[firstResponse?.id] == true
+        val responseSecondTryHasChatGPTEvaluation: Boolean = longBooleanMap[secondResponse?.id] == true
 
 
         // Get the "My results" data for the learner
@@ -76,11 +76,12 @@ class LearnerResultPhaseExecutionLoader(
         }
 
         // If both responses are null, then the chatGptEvaluation will be null
-        val evaluation =
-            (secondResponse ?: firstResponse).let { chatGptEvaluationService.findEvaluationByResponse(it) }
+        val chatGptEvaluation = listOfNotNull(secondResponse, firstResponse)
+            .firstOrNull()
+            ?.let { chatGptEvaluationService.findEvaluationByResponse(it) }
 
         val myChatGptEvaluationModel = if (learnerPhase.learnerSequence.sequence.chatGptEvaluationEnabled) {
-            ChatGptEvaluationModelFactory.build(evaluation, learnerPhase.learnerSequence.sequence)
+            ChatGptEvaluationModelFactory.build(chatGptEvaluation, learnerPhase.learnerSequence.sequence)
         } else null
 
         LearnerResultPhaseExecution(

--- a/src/main/resources/templates/i18n/evaluation.properties
+++ b/src/main/resources/templates/i18n/evaluation.properties
@@ -7,8 +7,10 @@ evaluation.hiddenByYouReport=This evaluation is not visible, as it has been repo
 evaluation.action.showEvaluation=Show evaluation
 evaluation.action.hideEvaluation=Hide evaluation
 
-evaluation.action.showEvaluationContent=View hidden content
-evaluation.action.hideEvaluationContent=Mask hidden content
+evaluation.action.showHiddenContent=View hidden content
+evaluation.action.hideHiddenContent=Mask hidden content
+evaluation.action.showReportedContent=View reported content
+evaluation.action.hideReportedContent=Mask reported content
 
 evaluation.submitUtilityGrade.success.header=Utility grade saved
 evaluation.submitUtilityGrade.success.content=Your utility grade has been saved.

--- a/src/main/resources/templates/i18n/evaluation_en.properties
+++ b/src/main/resources/templates/i18n/evaluation_en.properties
@@ -7,8 +7,10 @@ evaluation.hiddenByYouReport=This evaluation is not visible, as it has been repo
 evaluation.action.showEvaluation=Show evaluation
 evaluation.action.hideEvaluation=Hide evaluation
 
-evaluation.action.showEvaluationContent=View hidden content
-evaluation.action.hideEvaluationContent=Mask hidden content
+evaluation.action.showHiddenContent=View hidden content
+evaluation.action.hideHiddenContent=Mask hidden content
+evaluation.action.showReportedContent=View reported content
+evaluation.action.hideReportedContent=Mask reported content
 
 evaluation.submitUtilityGrade.success.header=Utility grade saved
 evaluation.submitUtilityGrade.success.content=Your utility grade has been saved.

--- a/src/main/resources/templates/i18n/evaluation_fr.properties
+++ b/src/main/resources/templates/i18n/evaluation_fr.properties
@@ -7,8 +7,10 @@ evaluation.hiddenByYouReport=Cette évaluation n'est pas visible, car elle a fai
 evaluation.action.showEvaluation=Réafficher l'évaluation
 evaluation.action.hideEvaluation=Masquer l'évaluation
 
-evaluation.action.showEvaluationContent=Voir le contenu masqué
-evaluation.action.hideEvaluationContent=Cacher le contenu masqué
+evaluation.action.showHiddenContent=Voir le contenu masqué
+evaluation.action.hideHiddenContent=Cacher le contenu masqué
+evaluation.action.showReportedContent=Voir le contenu signalé
+evaluation.action.hideReportedContent=Cacher le contenu signalé
 
 evaluation.submitUtilityGrade.success.header=Appréciation d'utilité enregistrée
 evaluation.submitUtilityGrade.success.content=Votre appréciation d'utilité a été enregistrée avec succès.

--- a/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-report-modal.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-report-modal.html
@@ -29,7 +29,7 @@
 
     <div class="content">
         <form th:id="${'report-form-' + evaluationId}"
-              th:action="@{/player/sequence/{sequenceId}/report-chat-gpt-evaluation(sequenceId=${chatGptEvaluationModel.sequenceId})}"
+              th:action="@{/chatGptEvaluation/sequence/{sequenceId}/report-chat-gpt-evaluation(sequenceId=${chatGptEvaluationModel.sequenceId})}"
               method="post">
             <div class="ui form">
                 <input type="hidden" name="evaluationId" th:value="${evaluationId}">

--- a/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-student-command.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-student-command.html
@@ -21,7 +21,7 @@
 
     <form class="ui form"
           style="align-items: end;"
-          th:action="@{/player/sequence/{sequenceId}/submit-utility-grade(sequenceId=${chatGptEvaluationModel.sequenceId})}"
+          th:action="@{/chatGptEvaluation/sequence/{sequenceId}/submit-utility-grade(sequenceId=${chatGptEvaluationModel.sequenceId})}"
           method="post">
         <input type="hidden" name="evaluationId" th:value="${chatGptEvaluationModel.evaluationId}">
         <div class="ui grid stackable" style="align-items: end;">

--- a/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-teacher-command.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-teacher-command.html
@@ -21,7 +21,7 @@
 
   <form class="ui form"
         style="align-items: end;"
-        th:action="@{/player/sequence/{sequenceId}/submit-utility-grade(sequenceId=${chatGptEvaluationModel.sequenceId})}"
+        th:action="@{/chatGptEvaluation/sequence/{sequenceId}/submit-utility-grade(sequenceId=${chatGptEvaluationModel.sequenceId})}"
         method="post">
     <input type="hidden" name="evaluationId" th:value="${chatGptEvaluationModel.evaluationId}">
     <div class="ui grid stackable" style="align-items: end;">

--- a/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-viewer.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-viewer.html
@@ -66,35 +66,44 @@
             </div>
         </div>
 
-        <!--/*
-        Hidden message when the teacher hides it.
-        It's only visible by the teacher because if an evaluation is hidden, only the teacher can see it.
-        */-->
-        <div class="review-border message-hidden" th:if="${chatGptEvaluationModel.hiddenByTeacher}">
-            <div th:text="#{evaluation.hiddenByTeacher}">Hidden by the teacher</div>
-            <div id="toggleContentDisplay" class="ui button black basic"
-                 style="text-transform: none; font-weight: initial"
-                 th:attr="evaluation-id=${chatGptEvaluationModel.gradingID}">
-
-                <span id="show" th:text="#{evaluation.action.showEvaluationContent}">Show hidden content</span>
-                <span id="hide" th:text="#{evaluation.action.hideEvaluationContent}"
-                      style="display: none;">Mask hidden content</span>
-            </div>
-        </div>
-
+        <!--/* Hidden message when the teacher hides it. It's only visible by the teacher because if an evaluation is hidden, only the teacher can see it.*/-->
         <!--/* Feedback message when the student reports the ChatGPTEvaluation */-->
-        <div class="review-border message-hidden" th:if="${!chatGptEvaluationModel.hiddenByTeacher && chatGptEvaluationModel.isReported()}">
-            <div th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation, it is hidden to you.</div>
-        </div>
+        <th:block
+                th:with="hidden=${chatGptEvaluationModel.hiddenByTeacher == true}, reported=${chatGptEvaluationModel.isReported() == true}">
+            <div class="review-border message-hidden" th:if="${hidden || reported}">
+                <!--/* Message */-->
+                <th:block>
+                    <div th:if="${hidden}" th:text="#{evaluation.hiddenByTeacher}">Hidden by the teacher</div>
+                    <div th:if="${reported && !hidden}" th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation,
+                        it is
+                        hidden to you.
+                    </div>
+                </th:block>
+                <!--/* Button to toggle the content */-->
+                <div id="toggleContentDisplay" class="ui button black basic"
+                     style="text-transform: none; font-weight: initial"
+                     th:attr="evaluation-id=${chatGptEvaluationModel.gradingID}">
+                    <th:block th:if="${hidden}">
+                        <span id="show" th:text="#{evaluation.action.showHiddenContent}">Show hidden content</span>
+                        <span id="hide" th:text="#{evaluation.action.hideHiddenContent}" style="display: none;">Mask hidden content</span>
+                    </th:block>
+                    <th:block th:if="${reported && !hidden}">
+                        <span id="show" th:text="#{evaluation.action.showReportedContent}">Show reported content</span>
+                        <span id="hide" th:text="#{evaluation.action.hideReportedContent}" style="display: none;">Mask reported content</span>
+                    </th:block>
+                </div>
+            </div>
+        </th:block>
 
         <!--/* Content */-->
-        <div class="review-border" th:if="${!chatGptEvaluationModel.hiddenByTeacher && !chatGptEvaluationModel.isReported()}">
+        <div class="review-border"
+             th:if="${!chatGptEvaluationModel.hiddenByTeacher && !chatGptEvaluationModel.isReported()}">
             <div th:replace="player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation.html :: chatGptEvaluation(${chatGptEvaluationModel})"></div>
         </div>
 
         <!--/* Container for the Content when the evaluation is hidden */-->
         <div class="review-border" th:attr="evaluation-id=${chatGptEvaluationModel.gradingID}" th:id="content"
-             th:if="${chatGptEvaluationModel.hiddenByTeacher}">
+             th:if="${chatGptEvaluationModel.hiddenByTeacher || chatGptEvaluationModel.isReported()}">
             <div th:replace="player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation.html :: chatGptEvaluation(${chatGptEvaluationModel})"></div>
         </div>
 

--- a/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-viewer.html
+++ b/src/main/resources/templates/player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation-viewer.html
@@ -74,13 +74,13 @@
                 <!--/* Message */-->
                 <th:block>
                     <div th:if="${hidden}" th:text="#{evaluation.hiddenByTeacher}">Hidden by the teacher</div>
-                    <div th:if="${reported && !hidden}" th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation,
-                        it is
-                        hidden to you.
+                    <div th:if="${reported && !hidden}" th:text="#{evaluation.hiddenByYouReport}">This evaluation have
+                        been reported
                     </div>
                 </th:block>
                 <!--/* Button to toggle the content */-->
                 <div id="toggleContentDisplay" class="ui button black basic"
+                     th:if="${chatGptEvaluationModel.canHideGrading}"
                      style="text-transform: none; font-weight: initial"
                      th:attr="evaluation-id=${chatGptEvaluationModel.gradingID}">
                     <th:block th:if="${hidden}">
@@ -103,7 +103,7 @@
 
         <!--/* Container for the Content when the evaluation is hidden */-->
         <div class="review-border" th:attr="evaluation-id=${chatGptEvaluationModel.gradingID}" th:id="content"
-             th:if="${chatGptEvaluationModel.hiddenByTeacher || chatGptEvaluationModel.isReported()}">
+             th:if="${(chatGptEvaluationModel.hiddenByTeacher || chatGptEvaluationModel.isReported()) && chatGptEvaluationModel.canHideGrading}">
             <div th:replace="player/assignment/sequence/components/chat-gpt-evaluation/_chat-gpt-evaluation.html :: chatGptEvaluation(${chatGptEvaluationModel})"></div>
         </div>
 

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -22,7 +22,7 @@
      xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
 
     <div class="review" th:with="explanation = ${draxoEvaluationModel.draxoEvaluation.getExplanation()}"
-         th:classappend="${draxoEvaluationModel.hiddenByTeacher || (draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)} ? 'hidden' : ''">
+         th:classappend="${draxoEvaluationModel.hiddenByTeacher || draxoEvaluationModel.isReported()} ? 'hidden' : ''">
 
         <!--/* PeerGrading header */-->
         <div class="review-header review-border" style="padding: 0 10px 0 0">
@@ -37,7 +37,8 @@
                           th:text="${draxoEvaluationModel.userCanDisplayStudentsIdentity} ? ${draxoEvaluationModel.graderName} : ${draxoEvaluationModel.graderNum}"></span>
                 </div>
                 <!--/* Score */-->
-                <div class="score" th:if="${!draxoEvaluationModel.hiddenByTeacher}">
+                <div class="score"
+                     th:if="${!draxoEvaluationModel.hiddenByTeacher && !draxoEvaluationModel.isReported()}">
                     <span th:text="#{evaluation.score} + ' :'">Score</span>
                     <div class="ui label">
                         <span th:text="${draxoEvaluationModel.prettyScore()}">2.5</span>
@@ -68,22 +69,36 @@
             </div>
         </div>
 
-        <!--/*
-        Hidden message when the teacher hides it.
-        It's only visible by the teacher because if an evaluation is hidden, only the teacher can see it.
-        */-->
-        <div class="review-border message-hidden" th:if="${draxoEvaluationModel.hiddenByTeacher}">
-            <div th:text="#{evaluation.hiddenByTeacher}">Hidden by the teacher</div>
-            <div id="toggleContentDisplay" class="ui button black basic"
-                 style="text-transform: none; font-weight: initial"
-                 th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}">
-                <span id="show" th:text="#{evaluation.action.showEvaluationContent}">Show hidden content</span>
-                <span id="hide" th:text="#{evaluation.action.hideEvaluationContent}" style="display: none;">Mask hidden content</span>
+        <!--/* Hidden message when the teacher hides it. It's only visible by the teacher because if an evaluation is hidden, only the teacher can see it. */-->
+        <!--/* Feedback message when the student reports the DraxoPeerGrading */-->
+        <th:block th:with="hidden=${draxoEvaluationModel.hiddenByTeacher == true}, reported=${draxoEvaluationModel.isReported() == true}">
+            <div class="review-border message-hidden" th:if="${hidden || reported}">
+                <!--/* Message */-->
+                <th:block>
+                    <div th:if="${hidden}" th:text="#{evaluation.hiddenByTeacher}">Hidden by the teacher</div>
+                    <div th:if="${reported}" th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation,
+                        it is
+                        hidden to you.
+                    </div>
+                </th:block>
+                <!--/* Button to toggle the content */-->
+                <div id="toggleContentDisplay" class="ui button black basic"
+                     style="text-transform: none; font-weight: initial"
+                     th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}">
+                    <th:block th:if="${hidden}">
+                        <span id="show" th:text="#{evaluation.action.showHiddenContent}">Show hidden content</span>
+                        <span id="hide" th:text="#{evaluation.action.hideHiddenContent}" style="display: none;">Mask hidden content</span>
+                    </th:block>
+                    <th:block th:if="${reported}">
+                        <span id="show" th:text="#{evaluation.action.showReportedContent}">Show reported content</span>
+                        <span id="hide" th:text="#{evaluation.action.hideReportedContent}" style="display: none;">Mask reported content</span>
+                    </th:block>
+                </div>
             </div>
-        </div>
+        </th:block>
 
         <!--/* Grid Draxo */-->
-        <div th:if="${!draxoEvaluationModel.hiddenByTeacher && !(draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}"
+        <div th:if="${!draxoEvaluationModel.hiddenByTeacher && !draxoEvaluationModel.isReported()}"
              class="draxo-content">
             <th:block
                     th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
@@ -95,10 +110,12 @@
         */-->
         <div class="draxo-content" th:id="draxoContent"
              th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
-             th:if="${draxoEvaluationModel.hiddenByTeacher}">
+             th:if="${draxoEvaluationModel.hiddenByTeacher || draxoEvaluationModel.isReported()}">
             <th:block
                     th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
         </div>
+
+
         <!--/* Reaction for the DraxoPeerGrading */-->
         <div class="review-border"
              th:if="${draxoEvaluationModel.canReactOnPeerGrading && draxoEvaluationModel.canBeReacted()}">
@@ -106,14 +123,9 @@
                     th:replace="player/assignment/sequence/components/peer-grading-reaction/_peer-grading-draxo-reaction.html :: peerGradingEvaluationCommand(${draxoEvaluationModel})">
             </th:block>
         </div>
-        <!--/* Feedback message when the student reports the DraxoPeerGrading */-->
-        <div class="review-border message-hidden"
-             th:if="${!draxoEvaluationModel.hiddenByTeacher && (draxoEvaluationModel.isReported() && draxoEvaluationModel.canReactOnPeerGrading)}"
-        >
-            <div th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation, it is hidden to you.</div>
-        </div>
     </div>
-    <!--/* Feedback message when the teacher hides a peergrading */-->
+
+    <!--/* Ascynchronous feedback message when the teacher hides a peergrading and something went wrong */-->
     <div class="ui message negative" th:attr="data-evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
          id="feedbackMessage" style="display: none;">
         <i class="close icon"></i>

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -76,7 +76,7 @@
                 <!--/* Message */-->
                 <th:block>
                     <div th:if="${hidden}" th:text="#{evaluation.hiddenByTeacher}">Hidden by the teacher</div>
-                    <div th:if="${reported}" th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation,
+                    <div th:if="${reported && !hidden}" th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation,
                         it is
                         hidden to you.
                     </div>
@@ -89,7 +89,7 @@
                         <span id="show" th:text="#{evaluation.action.showHiddenContent}">Show hidden content</span>
                         <span id="hide" th:text="#{evaluation.action.hideHiddenContent}" style="display: none;">Mask hidden content</span>
                     </th:block>
-                    <th:block th:if="${reported}">
+                    <th:block th:if="${reported && !hidden}">
                         <span id="show" th:text="#{evaluation.action.showReportedContent}">Show reported content</span>
                         <span id="hide" th:text="#{evaluation.action.hideReportedContent}" style="display: none;">Mask reported content</span>
                     </th:block>

--- a/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
+++ b/src/main/resources/templates/player/assignment/sequence/phase/evaluation/method/draxo/_draxo-show.html
@@ -71,18 +71,19 @@
 
         <!--/* Hidden message when the teacher hides it. It's only visible by the teacher because if an evaluation is hidden, only the teacher can see it. */-->
         <!--/* Feedback message when the student reports the DraxoPeerGrading */-->
-        <th:block th:with="hidden=${draxoEvaluationModel.hiddenByTeacher == true}, reported=${draxoEvaluationModel.isReported() == true}">
+        <th:block
+                th:with="hidden=${draxoEvaluationModel.hiddenByTeacher == true}, reported=${draxoEvaluationModel.isReported() == true}">
             <div class="review-border message-hidden" th:if="${hidden || reported}">
                 <!--/* Message */-->
                 <th:block>
                     <div th:if="${hidden}" th:text="#{evaluation.hiddenByTeacher}">Hidden by the teacher</div>
-                    <div th:if="${reported && !hidden}" th:text="#{evaluation.hiddenByYouReport}">As you reported this evaluation,
-                        it is
-                        hidden to you.
+                    <div th:if="${reported && !hidden}" th:text="#{evaluation.hiddenByYouReport}">This evaluation have
+                        been reported
                     </div>
                 </th:block>
                 <!--/* Button to toggle the content */-->
                 <div id="toggleContentDisplay" class="ui button black basic"
+                     th:if="${draxoEvaluationModel.canHidePeerGrading}"
                      style="text-transform: none; font-weight: initial"
                      th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}">
                     <th:block th:if="${hidden}">
@@ -110,7 +111,7 @@
         */-->
         <div class="draxo-content" th:id="draxoContent"
              th:attr="evaluation-id=${draxoEvaluationModel.draxoPeerGradingId}"
-             th:if="${draxoEvaluationModel.hiddenByTeacher || draxoEvaluationModel.isReported()}">
+             th:if="${(draxoEvaluationModel.hiddenByTeacher || draxoEvaluationModel.isReported()) && draxoEvaluationModel.canHidePeerGrading}">
             <th:block
                     th:replace="player/assignment/sequence/phase/evaluation/method/draxo/_draxo-content.html :: draxoPeerGradingContent(${draxoEvaluationModel})"></th:block>
         </div>


### PR DESCRIPTION
# Result

The DRAXO and ChatGPT evaluation have the same behavior for when they are hidden or reported

### Teacher view
An DRAXO evaluation reported.
An ChatGPT evaluation hidden and with the hidden content displayed
![image](https://github.com/user-attachments/assets/2b8ec40c-f664-4fdd-97ea-7b3db1e72e0f)

### Student view

An DRAXO evaluation reported
The ChatGPT evaluation from above isn't displayed because :
1- it's hidden
2- this student doesn't own the answer, so he can't see the evaluation
![image](https://github.com/user-attachments/assets/1b314f18-b5a6-430f-8e02-e56e2e3d7224)


In a case when the student own the answer : 
Same between DRAXO and ChatGPT
![image](https://github.com/user-attachments/assets/f9c84f5c-92ab-486e-9d95-860086858b47)
