### PR TITLE
Align keycloak rules on elaastic

### DIFF
--- a/authentication/README.md
+++ b/authentication/README.md
@@ -5,7 +5,7 @@ This folder contains the configuration files for the Keycloak server.
 ## Setup environment
 You must set the Keycloak admin password using the environment variable `KEYCLOAK_ADMIN_PASSWORD`.
 This can be achieved by defining your own `.env` file at the project root (it will be used by docker-compose).
-See `.env.template`.
+See `.env.template` at the root of the project.
 
 ## `/realms`
 
@@ -14,9 +14,16 @@ This folder contains the configuration files for the realms in Keycloak.
 For now the single configuration file is `elaastic-keycloak-realm.json`.
 
 It describes the realm `elaastic-keycloak` with the following configuration:
-- Two users:
-  - username: `brice` | password: `secret` | role: `NICE`
-  - username: `igor` | password: `secret`
+
+- Some users:
+
+| username | password | role | Comment                         |
+|----------|----------|:----:|---------------------------------|
+| brice    | secret   | NICE |                                 |
+| igor     | secret   |  /   |                                 |
+| janedoe  | secret   |  /   | Has the same email as `johndoe` |
+| johndoe  | secret   |  /   | Has the same email as `janedoe` |
+
 - A client : 
   - name: `elaastic`
 

--- a/authentication/keycloak/realms/elaastic-keycloak-realm.json
+++ b/authentication/keycloak/realms/elaastic-keycloak-realm.json
@@ -31,8 +31,8 @@
     "registrationEmailAsUsername": false,
     "rememberMe": false,
     "verifyEmail": false,
-    "loginWithEmailAllowed": true,
-    "duplicateEmailsAllowed": false,
+    "loginWithEmailAllowed": false,
+    "duplicateEmailsAllowed": true,
     "resetPasswordAllowed": false,
     "editUsernameAllowed": false,
     "bruteForceProtected": false,
@@ -425,6 +425,7 @@
     "requiredCredentials": [
         "password"
     ],
+    "passwordPolicy": "length(3)",
     "otpPolicyType": "totp",
     "otpPolicyAlgorithm": "HmacSHA1",
     "otpPolicyInitialCounter": 0,
@@ -511,6 +512,60 @@
                     "createdDate": 1721511590667,
                     "secretData": "{\"value\":\"Ji6U5BnPolyAvzhFBDRcYDXYNtQqena8Z2H0IC96TcE0cIJyDKVyeRCvaE0f1FuuGAMc4vh6Lc1wCtk+vxv8hg==\",\"salt\":\"lMF3OdYfnpd0/8wagGxhfA==\",\"additionalParameters\":{}}",
                     "credentialData": "{\"hashIterations\":210000,\"algorithm\":\"pbkdf2-sha512\",\"additionalParameters\":{}}"
+                }
+            ],
+            "disableableCredentialTypes": [],
+            "requiredActions": [],
+            "realmRoles": [
+                "default-roles-elaastic-keycloak"
+            ],
+            "notBefore": 0,
+            "groups": []
+        },
+        {
+            "id": "5a2574e1-1817-4464-831b-301bf9149842",
+            "username": "janedoe",
+            "firstName": "Jane",
+            "lastName": "Doe",
+            "email": "j.doe@mail.com",
+            "emailVerified": true,
+            "createdTimestamp": 1744716162683,
+            "enabled": true,
+            "totp": false,
+            "credentials": [
+                {
+                    "id": "43b72d2e-d6fb-412f-b909-de1472bc75cf",
+                    "type": "password",
+                    "createdDate": 1744716942838,
+                    "secretData": "{\"value\":\"r1h4A3P0EPs3kR9lbXY5SZJDDVSJ0DOvVe1O8kRvie0=\",\"salt\":\"yO1/nWcQVK/5BeS527nwlA==\",\"additionalParameters\":{}}",
+                    "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
+                }
+            ],
+            "disableableCredentialTypes": [],
+            "requiredActions": [],
+            "realmRoles": [
+                "default-roles-elaastic-keycloak"
+            ],
+            "notBefore": 0,
+            "groups": []
+        },
+        {
+            "id": "6252c917-687d-4772-b1ea-920e4b389f33",
+            "username": "johndoe",
+            "firstName": "John",
+            "lastName": "Doe",
+            "email": "j.doe@mail.com",
+            "emailVerified": true,
+            "createdTimestamp": 1744715956801,
+            "enabled": true,
+            "totp": false,
+            "credentials": [
+                {
+                    "id": "16005e27-8dcd-4a9f-9bc8-3456050c0ee5",
+                    "type": "password",
+                    "createdDate": 1744716961457,
+                    "secretData": "{\"value\":\"h7W/rKOMyHYd/ctU1tMmOHi9qu8iWaWqcEW9qFl1/EA=\",\"salt\":\"qSuZ2Y6XHByDDOUk112ZKw==\",\"additionalParameters\":{}}",
+                    "credentialData": "{\"hashIterations\":5,\"algorithm\":\"argon2\",\"additionalParameters\":{\"hashLength\":[\"32\"],\"memory\":[\"7168\"],\"type\":[\"id\"],\"version\":[\"1.3\"],\"parallelism\":[\"1\"]}}"
                 }
             ],
             "disableableCredentialTypes": [],
@@ -1662,6 +1717,18 @@
                         "oidc-sha256-pairwise-sub-mapper",
                         "oidc-usermodel-property-mapper",
                         "oidc-full-name-mapper"
+                    ]
+                }
+            }
+        ],
+        "org.keycloak.userprofile.UserProfileProvider": [
+            {
+                "id": "76eeea7c-2c52-4927-8080-a2f8228f592c",
+                "providerId": "declarative-user-profile",
+                "subComponents": {},
+                "config": {
+                    "kc.user.profile.config": [
+                        "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{},\"pattern\":{\"pattern\":\"^[a-zA-Z0-9_-]{1,31}$\",\"error-message\":\"\"},\"length\":{\"min\":\"1\",\"max\":\"31\"}},\"annotations\":{},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"annotations\":{},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"person-name-prohibited-characters\":{},\"length\":{\"min\":\"1\",\"max\":\"255\"}},\"annotations\":{},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"min\":1,\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}]}"
                     ]
                 }
             }


### PR DESCRIPTION
close #343 

Les règles de connexions de Keycloak ont été mis à jour pour correspondre aux règles présentes sur Elaastic.

Voici ce qui a été changé :

- Longueur minimale du password
- Longueur maximale pour l'username
- Lettre | Chiffre | '_' | '-' pour l'username
- Prénom et Nom de famille, non vide
- Email pas unique

Deux nouveaux utilisateurs ont été créer pour tester la non-unicité de l'email.
