### PR TITLE
Feat/335 link redirect to openid connect

### DIFF
--- a/server/src/main/kotlin/org/elaastic/auth/cas/CasController.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/cas/CasController.kt
@@ -9,16 +9,21 @@ import javax.servlet.http.HttpServletRequest
 class CasController {
 
     /**
-     * URL of the form /cas/{casKey}/{remaining-path} are secured by the CAS server identified by {casKey}
+     * Redirect the authenticated user to the `{remaining-path}` of the URL.
+     *
+     * URL of the form `/cas/{casKey}/{remaining-path}` are secured by the CAS server identified by `{casKey}`.
+     *
      * When the user is properly authenticated, this action will perform a redirect to {remaining-path} (queryString if
-     * any is preserved)
-     * When there is no authentication, the security config will handle to redirect the user on the CAS server login page.
+     * any is preserved). When there is no authentication, the security config will handle to redirect the user on the
+     * CAS server login page.
      */
-    @GetMapping("/cas/{casKey}/**", "/elaastic-questions/cas/{casKey}/**" )
-    fun casRedirect(request: HttpServletRequest, @PathVariable casKey: String) =
-        request.requestURL.toString().replace("/cas/$casKey", "", true).let {url ->
-            "redirect:$url"   +
-                    (if (request.queryString != null) "?${request.queryString}" else "")
+    @GetMapping("/cas/{casKey}/**", "/elaastic-questions/cas/{casKey}/**")
+    fun casRedirect(
+        request: HttpServletRequest,
+        @PathVariable casKey: String
+    ) = request.requestURL.toString()
+        .replace("/cas/$casKey", "", true)
+        .let { url ->
+            "redirect:$url${request.queryString?.let { "?$it" } ?: ""}"
         }
-
 }

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/OidcHintFilter.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/OidcHintFilter.kt
@@ -1,0 +1,55 @@
+package org.elaastic.auth.oauth
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.net.URLEncoder
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import kotlin.text.Charsets.UTF_8
+
+@Component
+class OidcHintFilter : OncePerRequestFilter() {
+
+    companion object {
+        const val TARGET_URL_SESSION_ATTR = "OIDC_TARGET_URL"
+        const val OIDC_HINT = "oidc_hint"
+    }
+
+    /** Filter only if the request has a parameter named "oidc_hint". */
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        return request.getParameter(OIDC_HINT) == null
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        chain: FilterChain
+    ) {
+        val realm = request.getParameter(OIDC_HINT)!!
+
+        val requestUri = request.requestURI
+        val cleanQuery = request.parameterMap
+            .filterKeys { it != OIDC_HINT }
+            .flatMap { (key, values) ->
+                values.map { value ->
+                    "${URLEncoder.encode(key, UTF_8.name())}=${URLEncoder.encode(value, UTF_8.name())}"
+                }
+            }
+            .joinToString("&")
+        val targetUrl = if (cleanQuery.isBlank()) requestUri else "$requestUri?$cleanQuery"
+
+        val auth = SecurityContextHolder.getContext().authentication
+        val isAuthenticated = auth?.isAuthenticated == true && auth !is AnonymousAuthenticationToken
+
+        if (isAuthenticated) {
+            response.sendRedirect(targetUrl)
+        } else {
+            request.getSession(true).setAttribute(TARGET_URL_SESSION_ATTR, targetUrl)
+            response.sendRedirect("/oauth2/authorization/$realm")
+        }
+    }
+
+}

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandler.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandler.kt
@@ -1,0 +1,24 @@
+package org.elaastic.auth.oauth
+
+import org.elaastic.auth.oauth.OidcHintFilter.Companion.TARGET_URL_SESSION_ATTR
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class OidcLoginSuccessHandler : AuthenticationSuccessHandler {
+
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        val targetUrl = request.session.getAttribute(TARGET_URL_SESSION_ATTR) as? String ?: "/"
+
+        request.session.removeAttribute(TARGET_URL_SESSION_ATTR)
+
+        response.sendRedirect(targetUrl)
+    }
+}

--- a/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
@@ -21,6 +21,7 @@ package org.elaastic.security
 import org.elaastic.auth.ElaasticLogoutSuccessHandler
 import org.elaastic.auth.cas.ElaasticUrlLogoutSuccessHandler
 import org.elaastic.auth.oauth.ElaasticOidcUserService
+import org.elaastic.auth.oauth.OidcHintFilter
 import org.elaastic.user.Role
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -46,9 +47,9 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.security.web.util.matcher.AnyRequestMatcher
-import java.net.URI
 
 
 @Configuration
@@ -111,6 +112,10 @@ class WebSecurityConfig(
                         oidcUserService = elaasticOidcUserService
                     }
                 }
+                http.addFilterBefore(
+                    OidcHintFilter(),
+                    UsernamePasswordAuthenticationFilter::class.java
+                )
             }
 
             val elaasticUrlLogoutSuccessHandler = ElaasticUrlLogoutSuccessHandler(

--- a/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
@@ -22,6 +22,7 @@ import org.elaastic.auth.ElaasticLogoutSuccessHandler
 import org.elaastic.auth.cas.ElaasticUrlLogoutSuccessHandler
 import org.elaastic.auth.oauth.ElaasticOidcUserService
 import org.elaastic.auth.oauth.OidcHintFilter
+import org.elaastic.auth.oauth.OidcLoginSuccessHandler
 import org.elaastic.user.Role
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -61,6 +62,7 @@ class WebSecurityConfig(
     @Autowired val encoder: PasswordEncoder,
     @Autowired val elaasticOidcUserService: ElaasticOidcUserService,
     @Autowired val clientRegistrationRepository: ClientRegistrationRepository,
+    private val oidcLoginSuccessHandler: OidcLoginSuccessHandler,
     @Value("\${elaastic.questions.url}") val elaasticUrl: String,
     @Value("\${elaastic.openid.enabled:false}") val elaasticOidcEnabled: Boolean,
 ) {
@@ -111,6 +113,7 @@ class WebSecurityConfig(
                     userInfoEndpoint {
                         oidcUserService = elaasticOidcUserService
                     }
+                    authenticationSuccessHandler = oidcLoginSuccessHandler
                 }
                 http.addFilterBefore(
                     OidcHintFilter(),

--- a/server/src/test/kotlin/org/elaastic/auth/cas/CasControllerTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/cas/CasControllerTest.kt
@@ -1,0 +1,38 @@
+package org.elaastic.auth.cas
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+
+class CasControllerTest {
+
+    @Test
+    fun `test casRedirect`() {
+        val localhost = "http://localhost"
+        var remaining = "remaining/path?query=string"
+        val casKey = "testKey"
+        CasController().casRedirect(
+            MockHttpServletRequest("GET", "/cas/$casKey/$remaining")
+                .addDefaultHeader(),
+            casKey
+        ).let { result ->
+            assertEquals("redirect:$localhost/$remaining", result)
+        }
+
+        remaining = "remaining/path"
+        CasController().casRedirect(
+            MockHttpServletRequest("GET", "/cas/$casKey/$remaining")
+                .addDefaultHeader(),
+            casKey
+        ).let { result ->
+            assertEquals("redirect:$localhost/$remaining", result)
+        }
+    }
+
+    private fun MockHttpServletRequest.addDefaultHeader(): MockHttpServletRequest {
+        addHeader("Host", "localhost")
+        addHeader("X-Forwarded-Host", "localhost")
+        addHeader("X-Forwarded-Prefix", "/elaastic-questions")
+        return this
+    }
+}

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
@@ -67,6 +67,28 @@ class OidcHintFilterTest {
     }
 
     @Test
+    fun `test doFilterInternal without parameter`() {
+        val oidcHintFilter = TestableOidcHintFilter()
+        val request = MockHttpServletRequest()
+        request.addParameter(OIDC_HINT, "test")
+        val target = "/test"
+        request.requestURI = target
+
+        val response = MockHttpServletResponse()
+
+        oidcHintFilter.testableDoFilterInternal(request, response, MockFilterChain())
+
+        // Check that the target URL is set correctly in the session
+        assertEquals(
+            target,
+            request.session?.getAttribute(TARGET_URL_SESSION_ATTR)
+        )
+
+        // Check that the redirect URL is correct
+        assertEquals("/oauth2/authorization/test", response.redirectedUrl)
+    }
+
+    @Test
     fun `test doFilterInternal with authenticated user`() {
         val oidcHintFilter = TestableOidcHintFilter()
         val request = MockHttpServletRequest()

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
@@ -1,0 +1,97 @@
+package org.elaastic.auth.oauth
+
+import org.elaastic.auth.oauth.OidcHintFilter.Companion.OIDC_HINT
+import org.elaastic.auth.oauth.OidcHintFilter.Companion.TARGET_URL_SESSION_ATTR
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import javax.servlet.FilterChain
+
+class OidcHintFilterTest {
+
+    /** To access non-public method in OidcHintFilter for testing purposes. */
+    class TestableOidcHintFilter : OidcHintFilter() {
+        fun testableShouldNotFilter(request: MockHttpServletRequest): Boolean {
+            return super.shouldNotFilter(request)
+        }
+
+        fun testableDoFilterInternal(
+            request: MockHttpServletRequest,
+            response: MockHttpServletResponse,
+            chain: FilterChain
+        ) {
+            super.doFilterInternal(request, response, chain)
+        }
+    }
+
+    @Test
+    fun `test shouldNotFilter`() {
+        val oidcHintFilter = TestableOidcHintFilter()
+        val request = MockHttpServletRequest()
+
+        assertNull(request.getParameter(OIDC_HINT))
+        assertTrue(oidcHintFilter.testableShouldNotFilter(request))
+
+        request.addParameter(OIDC_HINT, "test")
+
+        assertNotNull(request.getParameter(OIDC_HINT))
+        assertFalse(oidcHintFilter.testableShouldNotFilter(request))
+    }
+
+    @Test
+    fun `test doFilterInternal`() {
+        val oidcHintFilter = TestableOidcHintFilter()
+        val request = MockHttpServletRequest()
+        request.addParameter(OIDC_HINT, "test")
+        request.requestURI = "/test"
+        request.addParameter("param1", "value1")
+        request.addParameter("param2", "value2")
+
+        val response = MockHttpServletResponse()
+
+        oidcHintFilter.testableDoFilterInternal(request, response, MockFilterChain())
+
+        // Check that the target URL is set correctly in the session
+        assertEquals(
+            "/test?param1=value1&param2=value2",
+            request.session?.getAttribute(TARGET_URL_SESSION_ATTR)
+        )
+
+        // Check that the redirect URL is correct
+        assertEquals("/oauth2/authorization/test", response.redirectedUrl)
+    }
+
+    @Test
+    fun `test doFilterInternal with authenticated user`() {
+        val oidcHintFilter = TestableOidcHintFilter()
+        val request = MockHttpServletRequest()
+        request.addParameter(OIDC_HINT, "test")
+        val targetURL = "/test"
+        request.requestURI = targetURL
+
+        val response = MockHttpServletResponse()
+
+        // Set the SecurityContext with an STUB authenticated user
+        val authentication = UsernamePasswordAuthenticationToken(
+            "user",
+            null,
+            listOf(SimpleGrantedAuthority("ROLE_USER"))
+        )
+        val originalContext = SecurityContextHolder.getContext()
+        SecurityContextHolder.getContext().authentication = authentication
+
+        oidcHintFilter.testableDoFilterInternal(request, response, MockFilterChain())
+
+        // Check that the target URL is set correctly in the session
+        assertEquals(targetURL, response.redirectedUrl)
+
+        // Reset the SecurityContextHolder to its original state
+        SecurityContextHolder.clearContext()
+        SecurityContextHolder.setContext(originalContext)
+    }
+}

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
@@ -1,0 +1,52 @@
+package org.elaastic.auth.oauth
+
+import org.elaastic.auth.oauth.OidcHintFilter.Companion.TARGET_URL_SESSION_ATTR
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+
+class OidcLoginSuccessHandlerTest {
+
+    @Test
+    fun `onAuthenticationSuccess with session attribute`() {
+        val oidcLoginSuccessHandler = OidcLoginSuccessHandler()
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val authentication = UsernamePasswordAuthenticationToken("user", "password")
+
+        // Set the target URL in the session
+        val target = "/target"
+        request.session?.setAttribute(TARGET_URL_SESSION_ATTR, target)
+
+        oidcLoginSuccessHandler.onAuthenticationSuccess(request, response, authentication)
+
+        // Check that the target URL is removed from the session
+        assertNull(request.session?.getAttribute(TARGET_URL_SESSION_ATTR))
+
+        // Check that the response redirects to the target URL
+        assertEquals(302, response.status)
+        assertEquals(target, response.redirectedUrl)
+    }
+
+    @Test
+    fun `onAuthenticationSuccess without session attribute`() {
+        val oidcLoginSuccessHandler = OidcLoginSuccessHandler()
+        val request = MockHttpServletRequest()
+        val response = MockHttpServletResponse()
+        val authentication = UsernamePasswordAuthenticationToken("user", "password")
+
+        assertNull(request.session?.getAttribute(TARGET_URL_SESSION_ATTR))
+
+        oidcLoginSuccessHandler.onAuthenticationSuccess(request, response, authentication)
+
+        // Check that the target URL is removed from the session
+        assertNull(request.session?.getAttribute(TARGET_URL_SESSION_ATTR))
+
+        // Check that the response redirects to the target URL
+        assertEquals(302, response.status)
+        assertEquals("/", response.redirectedUrl)
+    }
+}


### PR DESCRIPTION
close #335 

Quand un utilisateur tente d'accéder à Elaastic avec une URL qui comporte le paramètre `oidc_hint`, alors il est redirigé vers le serveur d'authentification OAuth indiqué par la valeur du paramètre.

Actuellement le seul serveur qui est configuré est `keycloak`. 
Ainsi, quand un utilisateur tente d'accéder à `player/test?oidc_hint=keycloak`, il est redirigé vers le serveur keycloak dans le realm `elaastic-keycloak`. 
S'il se connecte, il sera finalement redirigé vers `/player/test`.