### PR TITLE
Fix/optional OIDC/1

### DIFF
--- a/docker-resources/cas/README.md
+++ b/docker-resources/cas/README.md
@@ -7,8 +7,8 @@ build and run a CAS server in development mode.
 The CAS server will use the auto-signed certificate ``./etc/cas/config/cas-certificate.cer``.
 
 This certificate must be loaded into the JVM used for running this Spring Boot webapp :
-```
-$JAVA_HOME/bin/keytool -importcert -cacerts -alias "cas-certificate" -file docker-resources/cas/etc/cas/config/cas-certificate.cer
+```bash
+"${JAVA_HOME}/bin/keytool" -importcert -cacerts -alias "cas-certificate" -file ./etc/cas/config/cas-certificate.cer
 ```
 
 The password for this autosigned testing certificate is : ``changeit``.
@@ -16,13 +16,13 @@ The password for this autosigned testing certificate is : ``changeit``.
 ## Generate an new self-signed certificate
 
 Step 1 : Generate the certificate
-```
+```bash
 $JAVA_HOME/bin/keytool -genkey -noprompt -keystore thekeystore -storepass changeit -keypass changeit -validity 3650 \
-            -keysize 2048 -keyalg RSA -alias cas-certificate -dname "CN=localhost, OU=MyOU, O=MyOrg, L=Somewhere, S=VA, C=US" \
+            -keysize 2048 -keyalg RSA -alias cas-certificate -dname "CN=localhost, OU=MyOU, O=MyOrg, L=Somewhere, S=VA, C=US"
 ```
 
 Step 2 : export it
-```
+```bash
 $JAVA_HOME/bin/keytool -export -alias cas-certificate -storepass changeit -file cas-certificate.cer -keystore thekeystore
 ```
 

--- a/server/src/main/kotlin/org/elaastic/auth/ElaasticLogoutSuccessHandler.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/ElaasticLogoutSuccessHandler.kt
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletResponse
  */
 class ElaasticLogoutSuccessHandler(
     private val elaasticUrlLogoutSuccessHandler: LogoutSuccessHandler,
-    private val oidcClientInitiatedLogoutSuccessHandler: OidcClientInitiatedLogoutSuccessHandler,
+    private val oidcClientInitiatedLogoutSuccessHandler: OidcClientInitiatedLogoutSuccessHandler? = null,
 ) : LogoutSuccessHandler {
 
     override fun onLogoutSuccess(
@@ -43,7 +43,7 @@ class ElaasticLogoutSuccessHandler(
         response: HttpServletResponse?,
         authentication: Authentication?
     ) {
-        if (authentication?.principal is ElaasticOidcUser) {
+        if (authentication?.principal is ElaasticOidcUser && oidcClientInitiatedLogoutSuccessHandler != null) {
             oidcClientInitiatedLogoutSuccessHandler.onLogoutSuccess(request, response, authentication)
         } else if (authentication is UsernamePasswordAuthenticationToken || authentication is CasAuthenticationToken) {
             elaasticUrlLogoutSuccessHandler.onLogoutSuccess(request, response, authentication)

--- a/server/src/main/kotlin/org/elaastic/auth/UserLinkService.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/UserLinkService.kt
@@ -44,7 +44,7 @@ class UserLinkService(
     @Autowired val roleService: RoleService,
 ) {
 
-    @Value("\${spring.security.oauth2.client.registration.keycloak.provider}")
+    @Value("\${spring.security.oauth2.client.registration.keycloak.provider:}")
     val oidcProvider: String = "oidcProvider default value"
 
     /**

--- a/server/src/main/kotlin/org/elaastic/auth/UserLinkService.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/UserLinkService.kt
@@ -31,6 +31,7 @@ import org.springframework.stereotype.Service
 import java.util.*
 import javax.transaction.Transactional
 
+// TODO This service should be generic and not specific to CAS and OIDC => Move the CAS and OIDC specific code to the respective calling service
 /**
  * Service to manage the link between Elaastic user and external authentication providers, like CAS or OIDC.
  *
@@ -58,7 +59,10 @@ class UserLinkService(
      */
     fun loadUserLinkByUsername(providerId: String, username: String): UserLink? {
         return userLinkRepository.findByProviderIdAndProviderUserId(providerId, username)
-            ?.also { it.user.casKey = providerId }
+            ?.also {
+                // TODO It is not consistent to inject providerId (which may designates an OIDC provider) into casKey
+                it.user.casKey = providerId
+            }
     }
 
     /**
@@ -110,7 +114,7 @@ class UserLinkService(
         )
 
         UserLink(
-            providerId = this.oidcProvider,
+            providerId = this.oidcProvider, // TODO I do not understand why getting statically the OIDC provider ; it should be extracted from the OIDC user
             providerUserId = oidcUser.name,
             user = user
         ).let(userLinkRepository::save)

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserService.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserService.kt
@@ -48,6 +48,7 @@ private const val ROLES_KEY = "roles"
  * @author John Tranier
  */
 @Service
+@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(prefix = "elaastic.openid", name = ["enabled"], havingValue = "true")
 class ElaasticOidcUserService(
     private val userLinkService: UserLinkService,
 ) : OidcUserService() {

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/OidcHintFilter.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/OidcHintFilter.kt
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletResponse
 import kotlin.text.Charsets.UTF_8
 
 @Component
+@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(prefix = "elaastic.openid", name = ["enabled"], havingValue = "true")
 class OidcHintFilter : OncePerRequestFilter() {
 
     companion object {

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandler.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandler.kt
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 @Component
+@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(prefix = "elaastic.openid", name = ["enabled"], havingValue = "true")
 class OidcLoginSuccessHandler : AuthenticationSuccessHandler {
 
     override fun onAuthenticationSuccess(

--- a/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
@@ -60,14 +60,14 @@ import java.nio.charset.StandardCharsets
 @EnableWebSecurity
 @EnableMethodSecurity(prePostEnabled = true)
 @Order(3)
-class WebSecurityConfig(
-    @Autowired val userDetailsService: UserDetailsService,
-    @Autowired val encoder: PasswordEncoder,
-    @Autowired val elaasticOidcUserService: ElaasticOidcUserService,
-    @Autowired val clientRegistrationRepository: ClientRegistrationRepository,
+open class WebSecurityConfig(
+    private val userDetailsService: UserDetailsService,
+    private val encoder: PasswordEncoder,
+    private val elaasticOidcUserService: ElaasticOidcUserService,
+    private val clientRegistrationRepository: ClientRegistrationRepository,
     private val oidcLoginSuccessHandler: OidcLoginSuccessHandler,
-    @Value("\${elaastic.questions.url}") val elaasticUrl: String,
-    @Value("\${elaastic.openid.enabled:false}") val elaasticOidcEnabled: Boolean,
+    @param:Value("\${elaastic.questions.url}") val elaasticUrl: String,
+    @param:Value("\${elaastic.openid.enabled:false}") val elaasticOidcEnabled: Boolean,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
@@ -80,7 +80,7 @@ class WebSecurityConfig(
     var casSecurityConfigurer: CasSecurityConfig.CasSecurityConfigurer? = null
 
     @Bean
-    fun webAuthenticationManager(): AuthenticationManager {
+    open fun webAuthenticationManager(): AuthenticationManager {
         val providers = mutableListOf<AuthenticationProvider>()
         providers.addAll(casSecurityConfigurer?.getCasAuthenticationProviderBeanList() ?: listOf())
         providers.add(daoAuthenticationProvider())
@@ -89,7 +89,7 @@ class WebSecurityConfig(
     }
 
     @Bean
-    fun webSecurityCustomize() =
+    open fun webSecurityCustomize() =
         WebSecurityCustomizer { web ->
             web.ignoring().requestMatchers(HttpMethod.POST, "/launch", "/elaastic-questions/launch")
 
@@ -97,7 +97,7 @@ class WebSecurityConfig(
 
     @Bean
     @Order(0)
-    fun resourceFilterChain(http: HttpSecurity): SecurityFilterChain {
+    open fun resourceFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .securityMatcher("/images/**", "/css/**", "/js/**", "/semantic/**", "/ckeditor/**")
             .authorizeHttpRequests { authorize -> authorize.anyRequest().permitAll() }
@@ -109,7 +109,7 @@ class WebSecurityConfig(
     }
 
     @Bean
-    fun webFilterChain(http: HttpSecurity): SecurityFilterChain {
+    open fun webFilterChain(http: HttpSecurity): SecurityFilterChain {
         http {
 
             if (elaasticOidcEnabled) {
@@ -237,7 +237,7 @@ class WebSecurityConfig(
 
 
     @Bean
-    fun daoAuthenticationProvider(): DaoAuthenticationProvider {
+    open fun daoAuthenticationProvider(): DaoAuthenticationProvider {
         DaoAuthenticationProvider().let {
             it.setUserDetailsService(userDetailsService)
             it.setPasswordEncoder(encoder)

--- a/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
@@ -63,10 +63,10 @@ import java.nio.charset.StandardCharsets
 open class WebSecurityConfig(
     private val userDetailsService: UserDetailsService,
     private val encoder: PasswordEncoder,
-    private val elaasticOidcUserService: ElaasticOidcUserService,
-    private val clientRegistrationRepository: ClientRegistrationRepository,
+    private val elaasticOidcUserServiceProvider: ObjectProvider<ElaasticOidcUserService>,
+    private val clientRegistrationRepositoryProvider: ObjectProvider<ClientRegistrationRepository>,
     private val casSecurityConfigurerProvider: ObjectProvider<CasSecurityConfig.CasSecurityConfigurer>,
-    private val oidcLoginSuccessHandler: OidcLoginSuccessHandler,
+    private val oidcLoginSuccessHandlerProvider: ObjectProvider<OidcLoginSuccessHandler>,
     @param:Value("\${elaastic.questions.url}") val elaasticUrl: String,
     @param:Value("\${elaastic.openid.enabled:false}") val elaasticOidcEnabled: Boolean,
 ) {
@@ -117,9 +117,11 @@ open class WebSecurityConfig(
                 oauth2Login {
                     Customizer.withDefaults<OAuth2LoginConfigurer<HttpSecurity>>()
                     userInfoEndpoint {
-                        oidcUserService = elaasticOidcUserService
+                        oidcUserService = elaasticOidcUserServiceProvider.getIfAvailable()
+                            ?: throw IllegalStateException("OIDC is enabled but ElaasticOidcUserService bean is missing")
                     }
-                    authenticationSuccessHandler = oidcLoginSuccessHandler
+                    authenticationSuccessHandler = oidcLoginSuccessHandlerProvider.getIfAvailable()
+                        ?: OidcLoginSuccessHandler()
                     /**
                      * Handle authentication failure
                      *
@@ -155,10 +157,15 @@ open class WebSecurityConfig(
             )
 
             val oidcClientInitiatedLogoutSuccessHandler =
-                OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository)
-                    .also {
-                        it.setPostLogoutRedirectUri(elaasticUrl)
+                if (elaasticOidcEnabled) {
+                    clientRegistrationRepositoryProvider.getIfAvailable()?.let { clientRegistrationRepository ->
+                        OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository)
+                            .also {
+                                it.setPostLogoutRedirectUri(elaasticUrl)
+                            }
                     }
+                } else null
+
 
             logout {
                 logoutRequestMatcher = AntPathRequestMatcher("/logout")

--- a/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
@@ -24,7 +24,7 @@ import org.elaastic.auth.oauth.*
 import org.elaastic.user.Role
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -65,6 +65,7 @@ open class WebSecurityConfig(
     private val encoder: PasswordEncoder,
     private val elaasticOidcUserService: ElaasticOidcUserService,
     private val clientRegistrationRepository: ClientRegistrationRepository,
+    private val casSecurityConfigurerProvider: ObjectProvider<CasSecurityConfig.CasSecurityConfigurer>,
     private val oidcLoginSuccessHandler: OidcLoginSuccessHandler,
     @param:Value("\${elaastic.questions.url}") val elaasticUrl: String,
     @param:Value("\${elaastic.openid.enabled:false}") val elaasticOidcEnabled: Boolean,
@@ -76,13 +77,13 @@ open class WebSecurityConfig(
         const val LOGIN_URL = "/login"
     }
 
-    @Autowired
-    var casSecurityConfigurer: CasSecurityConfig.CasSecurityConfigurer? = null
-
     @Bean
     open fun webAuthenticationManager(): AuthenticationManager {
         val providers = mutableListOf<AuthenticationProvider>()
-        providers.addAll(casSecurityConfigurer?.getCasAuthenticationProviderBeanList() ?: listOf())
+        providers.addAll(
+            casSecurityConfigurerProvider.getIfAvailable()
+                ?.getCasAuthenticationProviderBeanList() ?: listOf()
+        )
         providers.add(daoAuthenticationProvider())
 
         return ProviderManager(providers)
@@ -149,7 +150,7 @@ open class WebSecurityConfig(
 
             val elaasticUrlLogoutSuccessHandler = ElaasticUrlLogoutSuccessHandler(
                 "/",
-                casSecurityConfigurer?.casKeyToServerUrl ?: mapOf(),
+                casSecurityConfigurerProvider.getIfAvailable()?.casKeyToServerUrl ?: mapOf(),
                 "/logout?service=${elaasticUrl}"
             )
 
@@ -214,7 +215,7 @@ open class WebSecurityConfig(
                         // If a request without authentication get a URL of the form /cas/<casKey>/** the corresponding
                         // CasAuthenticationEntryPoint will be triggered (resulting in a redirect on the corresponding
                         // CAS server)
-                        *casSecurityConfigurer?.getCasAuthenticationEntryPoints() ?: arrayOf(),
+                        *casSecurityConfigurerProvider.getIfAvailable()?.getCasAuthenticationEntryPoints() ?: arrayOf(),
 
                         // Any other secured URL is handled by the native elaastic authentication (the formLogin)
                         AnyRequestMatcher.INSTANCE to LoginUrlAuthenticationEntryPoint(LOGIN_URL)

--- a/server/src/main/resources/application-dev.properties
+++ b/server/src/main/resources/application-dev.properties
@@ -9,3 +9,15 @@ spring.mail.username=
 spring.mail.password=
 spring.mail.protocol=smtp
 spring.mail.defaultEncoding=UTF-8
+
+# For activating OIDC authentication:
+# - Set elaastic.openid.enabled to true
+# - Uncomment the spring.security.oauth2.client.* lines below
+# - Launch the IAM server (see README.md)
+elaastic.openid.enabled = false
+#spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.local/realms/elaastic-keycloak
+#spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
+#spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
+#spring.security.oauth2.client.registration.keycloak.client-id=elaastic
+#spring.security.oauth2.client.registration.keycloak.client-secret=secret
+#spring.security.oauth2.client.registration.keycloak.scope=openid

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -30,13 +30,7 @@ spring.datasource.password=elaastic
 spring.flyway.locations=classpath:db/migration,classpath:org/elaastic/questions/migration
 
 # OAuth2 client
-elaastic.openid.enabled = true
-spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.local/realms/elaastic-keycloak
-spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
-spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.keycloak.client-id=elaastic
-spring.security.oauth2.client.registration.keycloak.client-secret=secret
-spring.security.oauth2.client.registration.keycloak.scope=openid
+elaastic.openid.enabled = false
 
 # Allowed waiting time for get the Datasource up and running
 spring.datasource.hikari.initializationFailTimeout=30000

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -30,6 +30,7 @@ spring.datasource.password=elaastic
 spring.flyway.locations=classpath:db/migration,classpath:org/elaastic/questions/migration
 
 # OAuth2 client
+elaastic.openid.enabled = true
 spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.local/realms/elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code


### PR DESCRIPTION
Fix #437 

### Description
- Improve beans management for CAS & OIDC by creating  beans only when neeed (clients are configured for CAS or OIDC)
- Deactivate OIDC by default
- Move the OIDC test client config to `application-dev.properties` + keep it commented for not using it by default