### PR TITLE
OIDC Config 

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: SPRING_PROFILES_ACTIVE=oidc ./server/gradlew build sonar --info
+        run: ./server/gradlew build sonar --info

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./server/gradlew build -Dspring.profiles.active=oidc sonar --info
+        run: SPRING_PROFILES_ACTIVE=oidc ./server/gradlew build sonar --info

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./server/gradlew build sonar --info
+        run: ./server/gradlew build -Dspring.profiles.active=oidc sonar --info

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: docker compose up -d traefik elaastic-questions-db-test-8 auth-iam
 
       - name: Build with Gradle
-        run: ./server/gradlew build -Dspring.profiles.active=oidc
+        run: SPRING_PROFILES_ACTIVE=oidc ./server/gradlew build
 
       - name: Copying test reports
         if: success() || failure()    # run this step even if previous step failed

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: docker compose up -d traefik elaastic-questions-db-test-8 auth-iam
 
       - name: Build with Gradle
-        run: ./server/gradlew build
+        run: ./server/gradlew build -Dspring.profiles.active=oidc
 
       - name: Copying test reports
         if: success() || failure()    # run this step even if previous step failed

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: docker compose up -d traefik elaastic-questions-db-test-8 auth-iam
 
       - name: Build with Gradle
-        run: SPRING_PROFILES_ACTIVE=oidc ./server/gradlew build
+        run: ./server/gradlew build
 
       - name: Copying test reports
         if: success() || failure()    # run this step even if previous step failed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
           KC_HTTP_ENABLED: true
           KC_HEALTH_ENABLED: true
           KC_METRICS_ENABLED: true
+      depends_on:
+          - traefik
 
   auth-idp-saml2:
       image: quay.io/keycloak/keycloak:25.0.6
@@ -101,6 +103,8 @@ services:
           KC_HTTP_ENABLED: true
           KC_HEALTH_ENABLED: true
           KC_METRICS_ENABLED: true
+      depends_on:
+          -   traefik
 
   traefik:
       image: traefik:v3.4

--- a/server/src/main/kotlin/org/elaastic/auth/local/LoginController.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/local/LoginController.kt
@@ -20,7 +20,7 @@ package org.elaastic.auth.local
 
 import org.elaastic.security.CasSecurityConfig
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.env.Environment
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.ui.set
@@ -32,8 +32,11 @@ import javax.servlet.http.HttpServletRequest
 @Controller
 class LoginController(
     @Autowired val casSecurityConfigurer: CasSecurityConfig.CasSecurityConfigurer,
-    @Value("\${elaastic.openid.enabled:false}") val elaasticOidcEnabled: Boolean,
+    @Autowired val environment: Environment,
 ) {
+
+    val elaasticOidcEnabled: Boolean
+        get() = environment.activeProfiles.contains("oidc")
 
     @GetMapping("/login")
     fun displayLoginForm(model: Model, request: HttpServletRequest): String {

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserService.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserService.kt
@@ -26,6 +26,7 @@ import org.elaastic.user.UserSource
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
@@ -53,7 +54,7 @@ private const val ROLES_KEY = "roles"
  * @author John Tranier
  */
 @Service
-@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(prefix = "elaastic.openid", name = ["enabled"], havingValue = "true")
+@Profile("oidc")
 open class ElaasticOidcUserService(
     private val userLinkService: UserLinkService,
 ) : OidcUserService() {

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/OidcHintFilter.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/OidcHintFilter.kt
@@ -1,5 +1,6 @@
 package org.elaastic.auth.oauth
 
+import org.springframework.context.annotation.Profile
 import org.springframework.security.authentication.AnonymousAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
@@ -11,7 +12,7 @@ import javax.servlet.http.HttpServletResponse
 import kotlin.text.Charsets.UTF_8
 
 @Component
-@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(prefix = "elaastic.openid", name = ["enabled"], havingValue = "true")
+@Profile("oidc")
 class OidcHintFilter : OncePerRequestFilter() {
 
     companion object {

--- a/server/src/main/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandler.kt
+++ b/server/src/main/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandler.kt
@@ -1,6 +1,7 @@
 package org.elaastic.auth.oauth
 
 import org.elaastic.auth.oauth.OidcHintFilter.Companion.TARGET_URL_SESSION_ATTR
+import org.springframework.context.annotation.Profile
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.security.web.savedrequest.SavedRequest
@@ -9,7 +10,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 @Component
-@org.springframework.boot.autoconfigure.condition.ConditionalOnProperty(prefix = "elaastic.openid", name = ["enabled"], havingValue = "true")
+@Profile("oidc")
 class OidcLoginSuccessHandler : AuthenticationSuccessHandler {
 
     override fun onAuthenticationSuccess(

--- a/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
+++ b/server/src/main/kotlin/org/elaastic/security/WebSecurityConfig.kt
@@ -25,10 +25,12 @@ import org.elaastic.user.Role
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
+import org.springframework.core.env.Environment
 import org.springframework.http.HttpMethod
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.AuthenticationProvider
@@ -68,10 +70,13 @@ open class WebSecurityConfig(
     private val casSecurityConfigurerProvider: ObjectProvider<CasSecurityConfig.CasSecurityConfigurer>,
     private val oidcLoginSuccessHandlerProvider: ObjectProvider<OidcLoginSuccessHandler>,
     @param:Value("\${elaastic.questions.url}") val elaasticUrl: String,
-    @param:Value("\${elaastic.openid.enabled:false}") val elaasticOidcEnabled: Boolean,
+    @Autowired val environment: Environment,
 ) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    val elaasticOidcEnabled: Boolean
+        get() = environment.activeProfiles.contains("oidc")
 
     companion object {
         const val LOGIN_URL = "/login"

--- a/server/src/main/resources/application-dev.properties
+++ b/server/src/main/resources/application-dev.properties
@@ -9,15 +9,3 @@ spring.mail.username=
 spring.mail.password=
 spring.mail.protocol=smtp
 spring.mail.defaultEncoding=UTF-8
-
-# For activating OIDC authentication:
-# - Set elaastic.openid.enabled to true
-# - Uncomment the spring.security.oauth2.client.* lines below
-# - Launch the IAM server (see README.md)
-elaastic.openid.enabled = false
-#spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
-#spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
-#spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
-#spring.security.oauth2.client.registration.keycloak.client-id=elaastic
-#spring.security.oauth2.client.registration.keycloak.client-secret=secret
-#spring.security.oauth2.client.registration.keycloak.scope=openid

--- a/server/src/main/resources/application-oidc.properties
+++ b/server/src/main/resources/application-oidc.properties
@@ -1,0 +1,11 @@
+# When activated, the application will use OpenID Connect for authentication.
+# The ODIC provider must be accessible when Elaastic bootstraps.
+# This default configuration matches the "auth-iam" services launched with Docker Compose in the development environment.
+# See README.md
+elaastic.openid.enabled = true
+spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
+spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
+spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.keycloak.client-id=elaastic
+spring.security.oauth2.client.registration.keycloak.client-secret=secret
+spring.security.oauth2.client.registration.keycloak.scope=openid

--- a/server/src/main/resources/application-oidc.properties
+++ b/server/src/main/resources/application-oidc.properties
@@ -2,7 +2,6 @@
 # The ODIC provider must be accessible when Elaastic bootstraps.
 # This default configuration matches the "auth-iam" services launched with Docker Compose in the development environment.
 # See README.md
-elaastic.openid.enabled = true
 spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -120,9 +120,6 @@ cas.ENT_3.logo=/images/cas/mbn.png
 cas.ENT_3.provider=Kosmos
 cas.ENT_3.protocol=3.0
 
-# OIDC is disabled by default. See the application-oidc.properties file for a sample configuration.
-elaastic.openid.enabled = false
-
 # REST API
 server.error.include-message=always
 rest.api.enabled=true

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -120,17 +120,8 @@ cas.ENT_3.logo=/images/cas/mbn.png
 cas.ENT_3.provider=Kosmos
 cas.ENT_3.protocol=3.0
 
-# For activating OIDC authentication:
-# - Set elaastic.openid.enabled to true
-# - Uncomment the spring.security.oauth2.client.* lines below
-# - Launch the IAM server (see README.md)
+# OIDC is disabled by default. See the application-oidc.properties file for a sample configuration.
 elaastic.openid.enabled = false
-#spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
-#spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
-#spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
-#spring.security.oauth2.client.registration.keycloak.client-id=elaastic
-#spring.security.oauth2.client.registration.keycloak.client-secret=secret
-#spring.security.oauth2.client.registration.keycloak.scope=openid
 
 # REST API
 server.error.include-message=always

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -29,9 +29,6 @@ spring.datasource.username=elaastic
 spring.datasource.password=elaastic
 spring.flyway.locations=classpath:db/migration,classpath:org/elaastic/questions/migration
 
-# OAuth2 client
-elaastic.openid.enabled = false
-
 # Allowed waiting time for get the Datasource up and running
 spring.datasource.hikari.initializationFailTimeout=30000
 
@@ -123,13 +120,24 @@ cas.ENT_3.logo=/images/cas/mbn.png
 cas.ENT_3.provider=Kosmos
 cas.ENT_3.protocol=3.0
 
+# For activating OIDC authentication:
+# - Set elaastic.openid.enabled to true
+# - Uncomment the spring.security.oauth2.client.* lines below
+# - Launch the IAM server (see README.md)
+elaastic.openid.enabled = false
+#spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
+#spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
+#spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
+#spring.security.oauth2.client.registration.keycloak.client-id=elaastic
+#spring.security.oauth2.client.registration.keycloak.client-secret=secret
+#spring.security.oauth2.client.registration.keycloak.scope=openid
+
 # REST API
 server.error.include-message=always
 rest.api.enabled=true
 rest.api.allowed_url=CHANGE ME in config/application.properties
 rest.user.name=CHANGE ME in config/application.properties
 rest.user.password=CHANGE ME in config/application.properties
-
 
 # ChatGPT API
 chatgptapi.token= CHANGE ME in config/application.properties

--- a/server/src/test/kotlin/org/elaastic/analytics/lrs/EventLogServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/analytics/lrs/EventLogServiceIntegrationTest.kt
@@ -18,13 +18,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.context.annotation.Profile
 import org.springframework.test.util.ReflectionTestUtils
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 internal class EventLogServiceIntegrationTest(
     @Autowired val integrationTestingService: IntegrationTestingService
     ) {

--- a/server/src/test/kotlin/org/elaastic/assignment/AssignmentServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/assignment/AssignmentServiceIntegrationTest.kt
@@ -52,7 +52,6 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.annotation.Profile
 import org.springframework.data.domain.PageRequest
 import org.springframework.security.access.AccessDeniedException
 import java.math.BigDecimal
@@ -66,7 +65,6 @@ import javax.validation.ConstraintViolationException
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 internal class AssignmentServiceIntegrationTest(
     @Autowired val assignmentService: AssignmentService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/auth/UserLinkServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/UserLinkServiceIntegrationTest.kt
@@ -18,23 +18,19 @@
 
 package org.elaastic.auth
 
-import org.elaastic.auth.cas.SupportedCasProvider
 import org.elaastic.test.IntegrationTestingService
 import org.elaastic.user.Role
 import org.elaastic.user.UserCreateCommand
 import org.elaastic.user.UserRepository
 import org.elaastic.user.UserSource
-import org.jasig.cas.client.authentication.AttributePrincipalImpl
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.annotation.Profile
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 open class UserLinkServiceIntegrationTest(
     @Autowired val userLinkService: UserLinkService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/auth/cas/CasAuthenticationUserDetailServiceTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/cas/CasAuthenticationUserDetailServiceTest.kt
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.context.annotation.Profile
 import org.springframework.security.cas.authentication.CasAssertionAuthenticationToken
 import java.util.*
 import javax.persistence.EntityManager
@@ -51,7 +50,6 @@ import javax.persistence.EntityManager
         UserLinkService::class
     ]
 )
-@Profile("test")
 class CasAuthenticationUserDetailServiceTest(
     @Autowired val userLinkService: UserLinkService,
 ) {

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
@@ -40,7 +40,6 @@ import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 open class ElaasticOidcUserServiceIntegrationTest(
     @Autowired val elaasticOidcUserService: ElaasticOidcUserService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
@@ -34,13 +34,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.context.annotation.Profile
-import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.test.context.ActiveProfiles
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("oidc")
+@ActiveProfiles("oidc")
 open class ElaasticOidcUserServiceIntegrationTest(
     @Autowired val elaasticOidcUserService: ElaasticOidcUserService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
@@ -34,12 +34,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.context.junit.jupiter.EnabledIf
+import org.springframework.test.context.ActiveProfiles
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@EnabledIf(value = "#{environment.acceptsProfiles('oidc')}", loadContext = true)
+@ActiveProfiles("oidc")
 open class ElaasticOidcUserServiceIntegrationTest(
     @Autowired val elaasticOidcUserService: ElaasticOidcUserService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
@@ -40,6 +40,7 @@ import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
+@Profile("oidc")
 open class ElaasticOidcUserServiceIntegrationTest(
     @Autowired val elaasticOidcUserService: ElaasticOidcUserService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/ElaasticOidcUserServiceIntegrationTest.kt
@@ -34,12 +34,12 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
-import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.EnabledIf
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@ActiveProfiles("oidc")
+@EnabledIf(value = "#{environment.acceptsProfiles('oidc')}", loadContext = true)
 open class ElaasticOidcUserServiceIntegrationTest(
     @Autowired val elaasticOidcUserService: ElaasticOidcUserService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
@@ -10,10 +10,10 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.EnabledIf
 import javax.servlet.FilterChain
 
-@ActiveProfiles("oidc")
+@EnabledIf(value = "#{environment.acceptsProfiles('oidc')}", loadContext = true)
 class OidcHintFilterTest {
 
     /** To access non-public method in OidcHintFilter for testing purposes. */

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
@@ -10,10 +10,10 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.test.context.junit.jupiter.EnabledIf
+import org.springframework.test.context.ActiveProfiles
 import javax.servlet.FilterChain
 
-@EnabledIf(value = "#{environment.acceptsProfiles('oidc')}", loadContext = true)
+@ActiveProfiles("oidc")
 class OidcHintFilterTest {
 
     /** To access non-public method in OidcHintFilter for testing purposes. */

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcHintFilterTest.kt
@@ -10,8 +10,10 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.ActiveProfiles
 import javax.servlet.FilterChain
 
+@ActiveProfiles("oidc")
 class OidcHintFilterTest {
 
     /** To access non-public method in OidcHintFilter for testing purposes. */

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
@@ -7,9 +7,9 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.web.savedrequest.SimpleSavedRequest
-import org.springframework.test.context.junit.jupiter.EnabledIf
+import org.springframework.test.context.ActiveProfiles
 
-@EnabledIf(value = "#{environment.acceptsProfiles('oidc')}", loadContext = true)
+@ActiveProfiles("oidc")
 class OidcLoginSuccessHandlerTest {
 
     @Test

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
@@ -7,7 +7,9 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.web.savedrequest.SimpleSavedRequest
+import org.springframework.test.context.ActiveProfiles
 
+@ActiveProfiles("oidc")
 class OidcLoginSuccessHandlerTest {
 
     @Test

--- a/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
+++ b/server/src/test/kotlin/org/elaastic/auth/oauth/OidcLoginSuccessHandlerTest.kt
@@ -7,9 +7,9 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.web.savedrequest.SimpleSavedRequest
-import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit.jupiter.EnabledIf
 
-@ActiveProfiles("oidc")
+@EnabledIf(value = "#{environment.acceptsProfiles('oidc')}", loadContext = true)
 class OidcLoginSuccessHandlerTest {
 
     @Test

--- a/server/src/test/kotlin/org/elaastic/consolidation/subject/PracticeSubjectServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/consolidation/subject/PracticeSubjectServiceIntegrationTest.kt
@@ -16,14 +16,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.annotation.Profile
 import java.time.LocalDateTime
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 internal class PracticeSubjectServiceIntegrationTest(
     @Autowired val practiceSubjectService: PracticeSubjectService,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/material/instructional/statement/StatementServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/material/instructional/statement/StatementServiceIntegrationTest.kt
@@ -11,14 +11,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.annotation.Profile
 import org.springframework.security.access.AccessDeniedException
 import javax.persistence.EntityNotFoundException
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 internal class StatementServiceIntegrationTest(
     @Autowired val statementService: StatementService,
     @Autowired val statementRepository: StatementRepository,

--- a/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectExportIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectExportIntegrationTest.kt
@@ -10,14 +10,12 @@ import org.hamcrest.MatcherAssert
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.annotation.Profile
 import java.io.File
 import java.util.*
 import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 class SubjectExportIntegrationTest(
     @Autowired val subjectExporter: SubjectExporter,
     @Autowired val subjectService: SubjectService,
@@ -42,13 +40,13 @@ class SubjectExportIntegrationTest(
             subject,
             Statement.createDefaultStatement(teacher)
                 .title("Stmt n 1")
-                .content("Content 1 - Avec des caractères accentués")
+                .content("Content 1 - Avec des caractï¿½res accentuï¿½s")
                 .expectedExplanation("Expected 1")
         )
         val statement2 = subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n°2")
+                .title("Stmt nï¿½2")
                 .content("Content 2")
         )
         val attachmentContent = "Attachement".toByteArray()

--- a/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectExportIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectExportIntegrationTest.kt
@@ -39,14 +39,14 @@ class SubjectExportIntegrationTest(
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n 1")
-                .content("Content 1 - Avec des caract�res accentu�s")
+                .title("Stmt n°1")
+                .content("Content 1 - Avec des caractères accentués")
                 .expectedExplanation("Expected 1")
         )
         val statement2 = subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n�2")
+                .title("Stmt n°2")
                 .content("Content 2")
         )
         val attachmentContent = "Attachement".toByteArray()

--- a/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectServiceIntegrationTest.kt
@@ -394,11 +394,11 @@ internal class SubjectServiceIntegrationTest(
                 owner = teacher,
                 course = course
             )
-    )
-    subjectService.addStatement(
-        subject,
-        Statement.createDefaultStatement(teacher)
-            .title("Stmt n°1")
+        )
+        subjectService.addStatement(
+            subject,
+            Statement.createDefaultStatement(teacher)
+                .title("Stmt n°1")
                 .content("Content 1")
         )
         subjectService.addStatement(

--- a/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectServiceIntegrationTest.kt
@@ -282,7 +282,7 @@ internal class SubjectServiceIntegrationTest(
             subjectService.addStatement(
                 subject,
                 Statement.createDefaultStatement(teacher)
-                    .title("Sequence n�1")
+                    .title("Sequence n°1")
                     .content("Content 1")
             )
         }.tThen {
@@ -302,7 +302,7 @@ internal class SubjectServiceIntegrationTest(
         val statement1 = subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(subject.owner)
-                .title("Statement n�1")
+                .title("Statement n°1")
                 .content("Content 1")
         )
 
@@ -394,17 +394,17 @@ internal class SubjectServiceIntegrationTest(
                 owner = teacher,
                 course = course
             )
-        )
-        subjectService.addStatement(
-            subject,
-            Statement.createDefaultStatement(teacher)
-                .title("Stmt n�1")
+    )
+    subjectService.addStatement(
+        subject,
+        Statement.createDefaultStatement(teacher)
+            .title("Stmt n°1")
                 .content("Content 1")
         )
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n�2")
+                .title("Stmt n°2")
                 .content("Content 2")
         )
 
@@ -458,13 +458,13 @@ internal class SubjectServiceIntegrationTest(
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n�1")
+                .title("Stmt n°1")
                 .content("Content 1")
         )
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n�2")
+                .title("Stmt n°2")
                 .content("Content 2")
         )
 
@@ -528,7 +528,7 @@ internal class SubjectServiceIntegrationTest(
         (1..n).forEach {
             subjectService.save(
                 Subject(
-                    title = "Subject n�$it",
+                    title = "Subject n°$it",
                     owner = owner
                 )
             )

--- a/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/material/instructional/subject/SubjectServiceIntegrationTest.kt
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.annotation.Profile
 import org.springframework.data.domain.PageRequest
 import org.springframework.security.access.AccessDeniedException
 import java.util.*
@@ -29,7 +28,6 @@ import javax.validation.ConstraintViolationException
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@Profile("test")
 internal class SubjectServiceIntegrationTest(
     @Autowired val subjectService: SubjectService,
     @Autowired val courseService: CourseService,
@@ -284,7 +282,7 @@ internal class SubjectServiceIntegrationTest(
             subjectService.addStatement(
                 subject,
                 Statement.createDefaultStatement(teacher)
-                    .title("Sequence n°1")
+                    .title("Sequence nï¿½1")
                     .content("Content 1")
             )
         }.tThen {
@@ -304,7 +302,7 @@ internal class SubjectServiceIntegrationTest(
         val statement1 = subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(subject.owner)
-                .title("Statement n°1")
+                .title("Statement nï¿½1")
                 .content("Content 1")
         )
 
@@ -400,13 +398,13 @@ internal class SubjectServiceIntegrationTest(
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n°1")
+                .title("Stmt nï¿½1")
                 .content("Content 1")
         )
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n°2")
+                .title("Stmt nï¿½2")
                 .content("Content 2")
         )
 
@@ -460,13 +458,13 @@ internal class SubjectServiceIntegrationTest(
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n°1")
+                .title("Stmt nï¿½1")
                 .content("Content 1")
         )
         subjectService.addStatement(
             subject,
             Statement.createDefaultStatement(teacher)
-                .title("Stmt n°2")
+                .title("Stmt nï¿½2")
                 .content("Content 2")
         )
 
@@ -530,7 +528,7 @@ internal class SubjectServiceIntegrationTest(
         (1..n).forEach {
             subjectService.save(
                 Subject(
-                    title = "Subject n°$it",
+                    title = "Subject nï¿½$it",
                     owner = owner
                 )
             )

--- a/server/src/test/kotlin/org/elaastic/user/legal/TermsServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/user/legal/TermsServiceIntegrationTest.kt
@@ -30,7 +30,7 @@ internal class TermsServiceIntegrationTest(
             // valid terms and terms contents
             Terms().let {
                 TermsContent("Terms in english", it, "en")
-                TermsContent("Terms en français", it)
+                TermsContent("Terms en franÃ§ais", it)
                 it
             }.tWhen {
                 // saving the terms
@@ -48,7 +48,7 @@ internal class TermsServiceIntegrationTest(
                 // fetching terms contents by language as expected
                 it.termsContentsByLanguage["fr"].let { tc ->
                     MatcherAssert.assertThat(tc!!.id, CoreMatchers.notNullValue())
-                    MatcherAssert.assertThat(tc.content, CoreMatchers.equalTo("Terms en français"))
+                    MatcherAssert.assertThat(tc.content, CoreMatchers.equalTo("Terms en franÃ§ais"))
                 }
                 it.termsContentsByLanguage["en"].let { tc ->
                     MatcherAssert.assertThat(tc!!.id, CoreMatchers.notNullValue())
@@ -65,13 +65,13 @@ internal class TermsServiceIntegrationTest(
             listOf<Terms>(
                 Terms(startDate = Date(), isActive = false).let {
                     TermsContent("Terms in english", it, "en")
-                    TermsContent("Terms en français", it)
+                    TermsContent("Terms en franÃ§ais", it)
                     it
                 },
                 // and an active terms
                 Terms().let {
                     TermsContent("Active Terms in english", it, "en")
-                    TermsContent("Terms en français", it)
+                    TermsContent("Terms en franÃ§ais", it)
                     it
                 }
             ).forEach {
@@ -95,13 +95,13 @@ internal class TermsServiceIntegrationTest(
                 // a terms
                 Terms().let {
                     TermsContent("Terms in english", it, "en")
-                    TermsContent("Terms en français", it)
+                    TermsContent("Terms en franÃ§ais", it)
                     termsService.save(it)
                 },
                 // and a new one
                 Terms().let {
                     TermsContent("New Terms in english", it, "en")
-                    TermsContent("Nouveaux Terms en français", it)
+                    TermsContent("Nouveaux Terms en franÃ§ais", it)
                     termsService.save(it)
                 }.tWhen {
                     // updating now inactive terms

--- a/server/src/test/resources/application-oidc.properties
+++ b/server/src/test/resources/application-oidc.properties
@@ -1,5 +1,4 @@
 # OAuth2 client
-elaastic.openid.enabled=true
 spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code

--- a/server/src/test/resources/application-oidc.properties
+++ b/server/src/test/resources/application-oidc.properties
@@ -1,5 +1,5 @@
 # OAuth2 client
-elaastic.openid.enabled = true
+elaastic.openid.enabled=true
 spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code

--- a/server/src/test/resources/application-oidc.properties
+++ b/server/src/test/resources/application-oidc.properties
@@ -1,0 +1,8 @@
+# OAuth2 client
+elaastic.openid.enabled = true
+spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
+spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
+spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.keycloak.client-id=elaastic
+spring.security.oauth2.client.registration.keycloak.client-secret=secret
+spring.security.oauth2.client.registration.keycloak.scope=openid

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -30,13 +30,7 @@ spring.datasource.password=elaastic
 spring.flyway.locations=classpath:db/migration,classpath:org/elaastic/questions/migration
 
 # OAuth2 client
-elaastic.openid.enabled = true
-spring.security.oauth2.client.provider.elaastic-keycloak.issuer-uri=http://iam.localhost/realms/elaastic-keycloak
-spring.security.oauth2.client.registration.keycloak.provider=elaastic-keycloak
-spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.keycloak.client-id=elaastic
-spring.security.oauth2.client.registration.keycloak.client-secret=secret
-spring.security.oauth2.client.registration.keycloak.scope=openid
+elaastic.openid.enabled = false
 
 # Allowed waiting time for get the Datasource up and running
 spring.datasource.hikari.initializationFailTimeout=30000

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -29,9 +29,6 @@ spring.datasource.username=elaastic
 spring.datasource.password=elaastic
 spring.flyway.locations=classpath:db/migration,classpath:org/elaastic/questions/migration
 
-# OAuth2 client
-elaastic.openid.enabled = false
-
 # Allowed waiting time for get the Datasource up and running
 spring.datasource.hikari.initializationFailTimeout=30000
 


### PR DESCRIPTION
Fix #468
- Move the OIDC config from `application-dev.properties` to `application-oidc.properties`
- Add the dependency between the 2 keycloak services and Traefik
- Create an `oidc` profile for activating OIDC in dev or test mode