### PR TITLE
John/chatgpt profile

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,4 @@
+# server
+
+## Spring profiles
+- `chatgpt`: Enables the use of ChatGPT for evaluating student responses.

--- a/server/src/main/kotlin/org/elaastic/ElaasticServer.kt
+++ b/server/src/main/kotlin/org/elaastic/ElaasticServer.kt
@@ -18,11 +18,14 @@
 
 package org.elaastic
 
+import org.elaastic.ai.evaluation.chatgpt.api.ChatGptApiProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-class ElaasticServer
+@EnableConfigurationProperties(ChatGptApiProperties::class)
+open class ElaasticServer
 
 fun main(args: Array<String>) {
 	runApplication<ElaasticServer>(*args)

--- a/server/src/main/kotlin/org/elaastic/ElaasticServer.kt
+++ b/server/src/main/kotlin/org/elaastic/ElaasticServer.kt
@@ -18,13 +18,12 @@
 
 package org.elaastic
 
-import org.elaastic.ai.evaluation.chatgpt.api.ChatGptApiProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@EnableConfigurationProperties(ChatGptApiProperties::class)
+@ConfigurationPropertiesScan("org.elaastic")
 open class ElaasticServer
 
 fun main(args: Array<String>) {

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationResponseStore.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationResponseStore.kt
@@ -4,7 +4,7 @@ package org.elaastic.ai.evaluation.chatgpt
  * Store the ids of responses that received a ChatGPT evaluation.
  *
  * @author John Tranier
- * @author François de Saint Palais
+ * @author FranÃ§ois de Saint Palais
  */
 class ChatGptEvaluationResponseStore(responseIds: Collection<Long> = emptyList()) {
 

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationService.kt
@@ -1,14 +1,9 @@
 package org.elaastic.ai.evaluation.chatgpt
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.elaastic.activity.response.Response
 import org.elaastic.activity.response.ResponseRepository
 import org.elaastic.activity.response.ResponseService
-import org.elaastic.ai.evaluation.chatgpt.api.ChatGptApiMessageData
-import org.elaastic.ai.evaluation.chatgpt.api.ChatGptCompletionService
-import org.elaastic.ai.evaluation.chatgpt.prompt.ChatGptPrompt
-import org.elaastic.ai.evaluation.chatgpt.prompt.ChatGptPromptService
 import org.elaastic.common.util.requireAccess
 import org.elaastic.moderation.ReportCandidateService
 import org.elaastic.moderation.UtilityGrade
@@ -17,80 +12,24 @@ import org.elaastic.sequence.interaction.Interaction
 import org.elaastic.user.User
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Propagation
-import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.util.*
-import java.util.logging.Level
 import java.util.logging.Logger
 import javax.persistence.EntityManager
 
 @Service
-class ChatGptEvaluationService(
+open class ChatGptEvaluationService(
     val chatGptEvaluationRepository: ChatGptEvaluationRepository,
     val responseRepository: ResponseRepository,
-    val chatGptPromptService: ChatGptPromptService,
     val reportCandidateService: ReportCandidateService,
     val responseService: ResponseService,
     val entityManager: EntityManager,
-    val chatGptCompletionService: ChatGptCompletionService,
     val messageSource: MessageSource,
 ) {
 
     val logger = Logger.getLogger(ChatGptEvaluationService::class.java.name)
     val locale: Locale = LocaleContextHolder.getLocale()
-
-    /**
-     * Create a ChatGPT evaluation for a response. The evaluation is created asynchronously.
-     *
-     * @param response the response to evaluate
-     * @param language the language of the evaluation
-     * @param chatGptExistingEvaluation the existing evaluation if it exists
-     * @return the created evaluation
-     */
-    @Async
-    @Transactional(propagation = Propagation.NEVER)
-    fun createEvaluation(
-        response: Response,
-        language: String,
-        chatGptExistingEvaluation: ChatGptEvaluation? = null
-    ): ChatGptEvaluation {
-        // get the default prompt for the language
-        val chatGptDefaultPrompt = chatGptPromptService.getPrompt(language)
-        // Initialization of the evaluation
-        val chatGptEvaluation = chatGptExistingEvaluation ?: ChatGptEvaluation(response = response)
-        chatGptEvaluation.prompt = chatGptDefaultPrompt
-        markEvaluationAsPending(chatGptEvaluation)
-        // build the prompt
-        val prompt = buildThePrompt(chatGptDefaultPrompt, response)
-        // build the evaluation
-        try {
-            // get the response from ChatGPT
-            logger.info("Generating response with ChatGPT for response ${response.id}")
-            logger.fine("Prompt: $prompt")
-            val generatedResponse = chatGptCompletionService.getChatGptResponse(
-                listOf(ChatGptApiMessageData(role = "user", content = prompt)),
-            ).messageList.first().content
-            logger.info("Response generated with ChatGPT for response ${response.id}")
-            logger.fine("Generated response: $generatedResponse")
-            // convert the generated response to a ChatGptEvaluationData object
-            val chatGptEvaluationData = ObjectMapper().readValue(
-                generatedResponse,
-                ChatGptEvaluationData::class.java
-            )
-            // finalize the evaluation
-            chatGptEvaluation.status = ChatGptEvaluationStatus.DONE.name
-            chatGptEvaluation.grade = chatGptEvaluationData.grade
-            chatGptEvaluation.annotation = chatGptEvaluationData.annotation
-        } catch (e: Exception) {
-            chatGptEvaluation.status = ChatGptEvaluationStatus.ERROR.name
-            logger.log(Level.SEVERE, "Error while evaluating response with ChatGPT: ${e.message}", e)
-        }
-        return chatGptEvaluationRepository.save(chatGptEvaluation)
-    }
-
 
     fun findEvaluationByResponse(response: Response): ChatGptEvaluation? =
         chatGptEvaluationRepository.findByResponse(response).takeIf { it?.removedByTeacher == false }
@@ -162,12 +101,6 @@ class ChatGptEvaluationService(
             reportComment,
             chatGptEvaluationRepository
         )
-    }
-
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    fun markEvaluationAsPending(chatGptEvaluation: ChatGptEvaluation): ChatGptEvaluation {
-        chatGptEvaluation.status = ChatGptEvaluationStatus.PENDING.name
-        return chatGptEvaluationRepository.saveAndFlush(chatGptEvaluation)
     }
 
     /**
@@ -312,34 +245,6 @@ class ChatGptEvaluationService(
             sequence.getResponseSubmissionInteraction(),
             removed = removed
         )
-    }
-
-    private fun buildThePrompt(
-        chatGptPrompt: ChatGptPrompt,
-        response: Response
-    ): String {
-        val questionTitle = response.statement.title
-        val questionStatement = response.statement.content
-        val teacherExplanation = response.statement.expectedExplanation
-        val studentExplanation = response.explanation
-
-        requireNotNull(teacherExplanation) { throw IllegalArgumentException("Error: You must define an expected explanation to create a ChatGPT evaluation") }
-        requireNotNull(studentExplanation) { throw IllegalArgumentException("Error: No explanation to evaluate") }
-
-        // add to the prompt the title, the question content, the teacher explanation and the student explanation as a json object
-        val promptData = PromptData(
-            questionTitle = questionTitle,
-            questionStatement = questionStatement,
-            teacherExplanation = teacherExplanation,
-            studentExplanation = studentExplanation,
-            studentChoices = response.learnerChoice,
-            studentScoreBasedOnChoices = response.score,
-        )
-
-        val objectMapper = ObjectMapper()
-        val jsonObject = objectMapper.writeValueAsString(promptData)
-
-        return chatGptPrompt.content + "\n" + jsonObject
     }
 
     /**

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationService.kt
@@ -15,7 +15,6 @@ import org.elaastic.moderation.UtilityGrade
 import org.elaastic.sequence.Sequence
 import org.elaastic.sequence.interaction.Interaction
 import org.elaastic.user.User
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.scheduling.annotation.Async
@@ -36,10 +35,7 @@ class ChatGptEvaluationService(
     val reportCandidateService: ReportCandidateService,
     val responseService: ResponseService,
     val entityManager: EntityManager,
-    /**
-     * chatGptCompletionService will be injected only if the ChatGPT is configured (see `chatgpt` profile).
-     */
-    @Autowired(required = false) val chatGptCompletionService: ChatGptCompletionService?,
+    val chatGptCompletionService: ChatGptCompletionService,
     val messageSource: MessageSource,
 ) {
 
@@ -61,8 +57,6 @@ class ChatGptEvaluationService(
         language: String,
         chatGptExistingEvaluation: ChatGptEvaluation? = null
     ): ChatGptEvaluation {
-        val chatGptCompletionService = chatGptCompletionService ?: throw IllegalStateException("ChatGPT is not configured")
-
         // get the default prompt for the language
         val chatGptDefaultPrompt = chatGptPromptService.getPrompt(language)
         // Initialization of the evaluation

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationService.kt
@@ -15,6 +15,7 @@ import org.elaastic.moderation.UtilityGrade
 import org.elaastic.sequence.Sequence
 import org.elaastic.sequence.interaction.Interaction
 import org.elaastic.user.User
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.MessageSource
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.scheduling.annotation.Async
@@ -35,7 +36,10 @@ class ChatGptEvaluationService(
     val reportCandidateService: ReportCandidateService,
     val responseService: ResponseService,
     val entityManager: EntityManager,
-    val chatGptCompletionService: ChatGptCompletionService,
+    /**
+     * chatGptCompletionService will be injected only if the ChatGPT is configured (see `chatgpt` profile).
+     */
+    @Autowired(required = false) val chatGptCompletionService: ChatGptCompletionService?,
     val messageSource: MessageSource,
 ) {
 
@@ -57,6 +61,8 @@ class ChatGptEvaluationService(
         language: String,
         chatGptExistingEvaluation: ChatGptEvaluation? = null
     ): ChatGptEvaluation {
+        val chatGptCompletionService = chatGptCompletionService ?: throw IllegalStateException("ChatGPT is not configured")
+
         // get the default prompt for the language
         val chatGptDefaultPrompt = chatGptPromptService.getPrompt(language)
         // Initialization of the evaluation

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptApiConfiguration.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptApiConfiguration.kt
@@ -1,11 +1,14 @@
 package org.elaastic.ai.evaluation.chatgpt.api
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.context.annotation.Profile
 
 @Profile("chatgpt")
 @ConfigurationProperties(prefix = "chatgptapi")
-class ChatGptApiProperties(
+data class ChatGptApiConfiguration
+
+@ConstructorBinding constructor(
     val token: String,
     val model: String,
     val maxTokens: Int,

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptApiProperties.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptApiProperties.kt
@@ -1,0 +1,10 @@
+package org.elaastic.ai.evaluation.chatgpt.api
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "chatgptapi")
+class ChatGptApiProperties(
+    val token: String,
+    val model: String,
+    val maxTokens: Int,
+)

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptApiProperties.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptApiProperties.kt
@@ -1,7 +1,9 @@
 package org.elaastic.ai.evaluation.chatgpt.api
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Profile
 
+@Profile("chatgpt")
 @ConfigurationProperties(prefix = "chatgptapi")
 class ChatGptApiProperties(
     val token: String,

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionService.kt
@@ -17,7 +17,25 @@
  */
 package org.elaastic.ai.evaluation.chatgpt.api
 
+import org.elaastic.activity.response.Response
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluation
+
 interface ChatGptCompletionService {
+
+    /**
+     * Create a ChatGPT evaluation for a response.
+     *
+     * @param response the response to evaluate
+     * @param language the language of the evaluation
+     * @param chatGptExistingEvaluation the existing evaluation if it exists
+     * @return the created evaluation
+     */
+    fun createEvaluation(
+        response: Response,
+        language: String,
+        chatGptExistingEvaluation: ChatGptEvaluation? = null
+    ): ChatGptEvaluation
+
     /**
      * Get the response from the ChatGPT API
      * @param messages List of messages to send to the API

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
 import java.util.logging.Logger
 
+@Profile("chatgpt")
 @Service
 class ChatGptCompletionService(
     val restTemplate: RestTemplate,

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
@@ -43,7 +43,7 @@ import java.util.logging.Logger
 @Profile("chatgpt")
 @Service
 open class DefaultChatGptCompletionService(
-    val chatGptApiProperties: ChatGptApiProperties,
+    val chatGptApiConfiguration: ChatGptApiConfiguration,
     val chatGptPromptService: ChatGptPromptService,
     val chatGptEvaluationRepository: ChatGptEvaluationRepository,
     val restTemplate: RestTemplate,
@@ -128,14 +128,14 @@ open class DefaultChatGptCompletionService(
 
     private fun getHeaders() = HttpHeaders().apply {
         contentType = MediaType.APPLICATION_JSON
-        set("Authorization", "Bearer ${chatGptApiProperties.token}")
+        set("Authorization", "Bearer ${chatGptApiConfiguration.token}")
     }
 
     private fun getRequestBody(messages: List<ChatGptApiMessageData>, nParameter: Int=1): String {
         val requestBody = mapOf(
-            "model" to chatGptApiProperties.model,
+            "model" to chatGptApiConfiguration.model,
             "messages" to messages,
-            "max_tokens" to chatGptApiProperties.maxTokens,
+            "max_tokens" to chatGptApiConfiguration.maxTokens,
             "n" to nParameter,
         )
         return objectMapper.writeValueAsString(requestBody)

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
@@ -19,19 +19,33 @@ package org.elaastic.ai.evaluation.chatgpt.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
+import org.elaastic.activity.response.Response
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluation
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationData
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationRepository
 import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationStatus
+import org.elaastic.ai.evaluation.chatgpt.PromptData
+import org.elaastic.ai.evaluation.chatgpt.prompt.ChatGptPrompt
+import org.elaastic.ai.evaluation.chatgpt.prompt.ChatGptPromptService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.client.RestTemplate
+import java.util.logging.Level
 import java.util.logging.Logger
 
 @Profile("chatgpt")
 @Service
-class DefaultChatGptCompletionService(
+open class DefaultChatGptCompletionService(
+    val chatGptPromptService: ChatGptPromptService,
+    val chatGptEvaluationRepository: ChatGptEvaluationRepository,
     val restTemplate: RestTemplate,
     val objectMapper: ObjectMapper,
     @Value("\${chatgptapi.token}")
@@ -48,6 +62,61 @@ class DefaultChatGptCompletionService(
         }
         // logger for this class
         val logger = Logger.getLogger(ChatGptEvaluationService::class.java.name)
+    }
+
+    /**
+     * Create a ChatGPT evaluation for a response. The evaluation is created asynchronously.
+     *
+     * @param response the response to evaluate
+     * @param language the language of the evaluation
+     * @param chatGptExistingEvaluation the existing evaluation if it exists
+     * @return the created evaluation
+     */
+    @Async
+    @Transactional(propagation = Propagation.NEVER)
+    override fun createEvaluation(
+        response: Response,
+        language: String,
+        chatGptExistingEvaluation: ChatGptEvaluation?
+    ): ChatGptEvaluation {
+        // get the default prompt for the language
+        val chatGptDefaultPrompt = chatGptPromptService.getPrompt(language)
+        // Initialization of the evaluation
+        val chatGptEvaluation = chatGptExistingEvaluation ?: ChatGptEvaluation(response = response)
+        chatGptEvaluation.prompt = chatGptDefaultPrompt
+        markEvaluationAsPending(chatGptEvaluation)
+        // build the prompt
+        val prompt = buildThePrompt(chatGptDefaultPrompt, response)
+        // build the evaluation
+        try {
+            // get the response from ChatGPT
+            logger.info("Generating response with ChatGPT for response ${response.id}")
+            logger.fine("Prompt: $prompt")
+            val generatedResponse = getChatGptResponse(
+                listOf(ChatGptApiMessageData(role = "user", content = prompt)),
+            ).messageList.first().content
+            logger.info("Response generated with ChatGPT for response ${response.id}")
+            logger.fine("Generated response: $generatedResponse")
+            // convert the generated response to a ChatGptEvaluationData object
+            val chatGptEvaluationData = ObjectMapper().readValue(
+                generatedResponse,
+                ChatGptEvaluationData::class.java
+            )
+            // finalize the evaluation
+            chatGptEvaluation.status = ChatGptEvaluationStatus.DONE.name
+            chatGptEvaluation.grade = chatGptEvaluationData.grade
+            chatGptEvaluation.annotation = chatGptEvaluationData.annotation
+        } catch (e: Exception) {
+            chatGptEvaluation.status = ChatGptEvaluationStatus.ERROR.name
+            logger.log(Level.SEVERE, "Error while evaluating response with ChatGPT: ${e.message}", e)
+        }
+        return chatGptEvaluationRepository.save(chatGptEvaluation)
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    open fun markEvaluationAsPending(chatGptEvaluation: ChatGptEvaluation): ChatGptEvaluation {
+        chatGptEvaluation.status = ChatGptEvaluationStatus.PENDING.name
+        return chatGptEvaluationRepository.saveAndFlush(chatGptEvaluation)
     }
 
     /**
@@ -78,4 +147,31 @@ class DefaultChatGptCompletionService(
         return objectMapper.writeValueAsString(requestBody)
     }
 
+    private fun buildThePrompt(
+        chatGptPrompt: ChatGptPrompt,
+        response: Response
+    ): String {
+        val questionTitle = response.statement.title
+        val questionStatement = response.statement.content
+        val teacherExplanation = response.statement.expectedExplanation
+        val studentExplanation = response.explanation
+
+        requireNotNull(teacherExplanation) { throw IllegalArgumentException("Error: You must define an expected explanation to create a ChatGPT evaluation") }
+        requireNotNull(studentExplanation) { throw IllegalArgumentException("Error: No explanation to evaluate") }
+
+        // add to the prompt the title, the question content, the teacher explanation and the student explanation as a json object
+        val promptData = PromptData(
+            questionTitle = questionTitle,
+            questionStatement = questionStatement,
+            teacherExplanation = teacherExplanation,
+            studentExplanation = studentExplanation,
+            studentChoices = response.learnerChoice,
+            studentScoreBasedOnChoices = response.score,
+        )
+
+        val objectMapper = ObjectMapper()
+        val jsonObject = objectMapper.writeValueAsString(promptData)
+
+        return chatGptPrompt.content + "\n" + jsonObject
+    }
 }

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
@@ -28,7 +28,6 @@ import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationStatus
 import org.elaastic.ai.evaluation.chatgpt.PromptData
 import org.elaastic.ai.evaluation.chatgpt.prompt.ChatGptPrompt
 import org.elaastic.ai.evaluation.chatgpt.prompt.ChatGptPromptService
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -44,16 +43,11 @@ import java.util.logging.Logger
 @Profile("chatgpt")
 @Service
 open class DefaultChatGptCompletionService(
+    val chatGptApiProperties: ChatGptApiProperties,
     val chatGptPromptService: ChatGptPromptService,
     val chatGptEvaluationRepository: ChatGptEvaluationRepository,
     val restTemplate: RestTemplate,
     val objectMapper: ObjectMapper,
-    @Value("\${chatgptapi.token}")
-    val apiKey: String,
-    @Value("\${chatgptapi.model}")
-    val model: String,
-    @Value("\${chatgptapi.maxTokens}")
-    val maxTokens: Int
 ) : ChatGptCompletionService {
     companion object {
         const val apiUrl = "https://api.openai.com/v1/chat/completions"
@@ -134,14 +128,14 @@ open class DefaultChatGptCompletionService(
 
     private fun getHeaders() = HttpHeaders().apply {
         contentType = MediaType.APPLICATION_JSON
-        set("Authorization", "Bearer $apiKey")
+        set("Authorization", "Bearer ${chatGptApiProperties.token}")
     }
 
     private fun getRequestBody(messages: List<ChatGptApiMessageData>, nParameter: Int=1): String {
         val requestBody = mapOf(
-            "model" to model,
+            "model" to chatGptApiProperties.model,
             "messages" to messages,
-            "max_tokens" to maxTokens,
+            "max_tokens" to chatGptApiProperties.maxTokens,
             "n" to nParameter,
         )
         return objectMapper.writeValueAsString(requestBody)

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DefaultChatGptCompletionService.kt
@@ -1,0 +1,81 @@
+/*
+ * Elaastic - formative assessment system
+ * Copyright (C) 2019. University Toulouse 1 Capitole, University Toulouse 3 Paul Sabatier
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.elaastic.ai.evaluation.chatgpt.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import java.util.logging.Logger
+
+@Profile("chatgpt")
+@Service
+class DefaultChatGptCompletionService(
+    val restTemplate: RestTemplate,
+    val objectMapper: ObjectMapper,
+    @Value("\${chatgptapi.token}")
+    val apiKey: String,
+    @Value("\${chatgptapi.model}")
+    val model: String,
+    @Value("\${chatgptapi.maxTokens}")
+    val maxTokens: Int
+) : ChatGptCompletionService {
+    companion object {
+        const val apiUrl = "https://api.openai.com/v1/chat/completions"
+        val module = SimpleModule().apply {
+            addDeserializer(ChatGptApiResponseData::class.java, ChatGptApiDeserializer())
+        }
+        // logger for this class
+        val logger = Logger.getLogger(ChatGptEvaluationService::class.java.name)
+    }
+
+    /**
+     * Get the response from the ChatGPT API
+     * @param messages List of messages to send to the API
+     * @return ChatGptApiResponseData
+     */
+    override fun getChatGptResponse(messages: List<ChatGptApiMessageData>, nParameter: Int): ChatGptApiResponseData {
+        val requestBody = getRequestBody(messages, nParameter)
+        val entity = HttpEntity(requestBody, getHeaders())
+        val responseEntity = restTemplate.postForEntity(apiUrl, entity, String::class.java)
+        objectMapper.registerModule(module)
+        return objectMapper.readValue(responseEntity.body, ChatGptApiResponseData::class.java)
+    }
+
+    private fun getHeaders() = HttpHeaders().apply {
+        contentType = MediaType.APPLICATION_JSON
+        set("Authorization", "Bearer $apiKey")
+    }
+
+    private fun getRequestBody(messages: List<ChatGptApiMessageData>, nParameter: Int=1): String {
+        val requestBody = mapOf(
+            "model" to model,
+            "messages" to messages,
+            "max_tokens" to maxTokens,
+            "n" to nParameter,
+        )
+        return objectMapper.writeValueAsString(requestBody)
+    }
+
+}

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DisabledChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DisabledChatGptCompletionService.kt
@@ -17,6 +17,8 @@
  */
 package org.elaastic.ai.evaluation.chatgpt.api
 
+import org.elaastic.activity.response.Response
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluation
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 
@@ -24,10 +26,15 @@ import org.springframework.stereotype.Service
 @Service
 class DisabledChatGptCompletionService : ChatGptCompletionService {
 
+    override fun createEvaluation(
+        response: Response,
+        language: String,
+        chatGptExistingEvaluation: ChatGptEvaluation?
+    ): ChatGptEvaluation = throw IllegalStateException("ChatGPT is disabled")
+
     override fun getChatGptResponse(
         messages: List<ChatGptApiMessageData>,
         nParameter: Int
-    ): ChatGptApiResponseData {
+    ): ChatGptApiResponseData =
         throw IllegalStateException("ChatGPT is disabled")
-    }
 }

--- a/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DisabledChatGptCompletionService.kt
+++ b/server/src/main/kotlin/org/elaastic/ai/evaluation/chatgpt/api/DisabledChatGptCompletionService.kt
@@ -17,11 +17,17 @@
  */
 package org.elaastic.ai.evaluation.chatgpt.api
 
-interface ChatGptCompletionService {
-    /**
-     * Get the response from the ChatGPT API
-     * @param messages List of messages to send to the API
-     * @return ChatGptApiResponseData
-     */
-    fun getChatGptResponse(messages: List<ChatGptApiMessageData>, nParameter: Int = 1): ChatGptApiResponseData
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Profile("!chatgpt")
+@Service
+class DisabledChatGptCompletionService : ChatGptCompletionService {
+
+    override fun getChatGptResponse(
+        messages: List<ChatGptApiMessageData>,
+        nParameter: Int
+    ): ChatGptApiResponseData {
+        throw IllegalStateException("ChatGPT is disabled")
+    }
 }

--- a/server/src/main/kotlin/org/elaastic/common/abtesting/ElaasticFeatures.kt
+++ b/server/src/main/kotlin/org/elaastic/common/abtesting/ElaasticFeatures.kt
@@ -1,6 +1,5 @@
 package org.elaastic.common.abtesting
 
-import org.togglz.core.Feature
 import org.togglz.core.annotation.ActivationParameter
 import org.togglz.core.annotation.DefaultActivationStrategy
 import org.togglz.core.annotation.EnabledByDefault
@@ -48,11 +47,13 @@ enum class ElaasticFeatures {
     @EnabledByDefault
     IMPORT_EXPORT,
 
-    @EnabledByDefault
+    /**
+     * Use Chat GPT for evaluating student responses.
+     */
     @DefaultActivationStrategy(
-        id = SomeTeachersAllStudentsActivationStrategy.ID,
+        id = SpringProfileActivationStrategy.ID,
         parameters = [
-            ActivationParameter(name = "users", value = "fsil")
+            ActivationParameter(name = "profiles", value = "chatgpt")
         ]
     )
     CHATGPT_EVALUATION,

--- a/server/src/main/kotlin/org/elaastic/player/PlayerController.kt
+++ b/server/src/main/kotlin/org/elaastic/player/PlayerController.kt
@@ -24,6 +24,7 @@ import org.elaastic.activity.response.ResponseService
 import org.elaastic.activity.results.AttemptNum
 import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationResponseStore
 import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.elaastic.ai.evaluation.chatgpt.api.ChatGptCompletionService
 import org.elaastic.analytics.lrs.EventLogService
 import org.elaastic.assignment.Assignment
 import org.elaastic.assignment.AssignmentService
@@ -73,10 +74,11 @@ import javax.transaction.Transactional
 
 @Controller
 @RequestMapping("/player", "/elaastic-questions/player")
-class PlayerController(
+open class PlayerController(
     @Autowired val anonymousUserService: AnonymousUserService,
     @Autowired val assignmentService: AssignmentService,
     @Autowired val chatGptEvaluationService: ChatGptEvaluationService,
+    @Autowired val chatGptCompletionService: ChatGptCompletionService,
     @Autowired val draxoPeerGradingService: DraxoPeerGradingService,
     @Autowired val eventLogService: EventLogService,
     @Autowired val interactionService: InteractionService,
@@ -171,7 +173,7 @@ class PlayerController(
      */
     @GetMapping("/start-anonymous-session")
     @Transactional
-    fun startAnonymousSession(
+    open fun startAnonymousSession(
         authentication: Authentication?,
         @RequestParam("nickname") nickname: String,
         @RequestParam("globalId") globalId: String,
@@ -523,7 +525,7 @@ class PlayerController(
         val response = sequenceService.submitResponse(user, sequence, responseSubmissionData)
         if (sequence.chatGptEvaluationEnabled && !sequence.isSecondAttemptAllowed()) {
             // Dead branch. `isSecondAttemptAllowed` is always true, so the whole condition is always false.
-            chatGptEvaluationService.createEvaluation(response, locale.language)
+            chatGptCompletionService.createEvaluation(response, locale.language)
         }
 
         return "redirect:/player/assignment/${sequence.assignment!!.id}/play/sequence/${id}"
@@ -613,7 +615,7 @@ class PlayerController(
         val response = responseService.find(user, sequence, 2) ?: responseService.find(user, sequence, 1)
         if (response != null) {
             val chatGptEvaluation = chatGptEvaluationService.findEvaluationByResponse(response)
-            chatGptEvaluationService.createEvaluation(response, locale.language, chatGptEvaluation)
+            chatGptCompletionService.createEvaluation(response, locale.language, chatGptEvaluation)
         }
 
         return "redirect:/player/assignment/${sequence.assignment!!.id}/play/sequence/${sequenceId}"

--- a/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/AbstractEvaluationPhaseExecutionController.kt
+++ b/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/AbstractEvaluationPhaseExecutionController.kt
@@ -4,7 +4,7 @@ import org.elaastic.activity.response.ConfidenceDegree
 import org.elaastic.activity.response.Response
 import org.elaastic.activity.response.ResponseService
 import org.elaastic.activity.results.ItemIndex
-import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.elaastic.ai.evaluation.chatgpt.api.ChatGptCompletionService
 import org.elaastic.material.instructional.question.legacy.LearnerChoice
 import org.elaastic.sequence.Sequence
 import org.elaastic.sequence.SequenceService
@@ -14,7 +14,7 @@ import java.util.*
 abstract class AbstractEvaluationPhaseExecutionController(
     open val sequenceService: SequenceService,
     open val responseService: ResponseService,
-    open val chatGptEvaluationService: ChatGptEvaluationService
+    open val chatGptCompletionService: ChatGptCompletionService,
 ) {
 
     fun changeAnswer(user: User, sequence: Sequence, answer: Answer): Response {
@@ -68,7 +68,7 @@ abstract class AbstractEvaluationPhaseExecutionController(
         }
 
         if (sequence.chatGptEvaluationEnabled && lastResponse != null) {
-            chatGptEvaluationService.createEvaluation(lastResponse, locale.language)
+            chatGptCompletionService.createEvaluation(lastResponse, locale.language)
         }
 
         return "redirect:/player/assignment/${assignmentId}/play/sequence/${sequence.id}"

--- a/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/all_at_once/AllAtOnceEvaluationPhaseExecutionController.kt
+++ b/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/all_at_once/AllAtOnceEvaluationPhaseExecutionController.kt
@@ -5,7 +5,7 @@ import org.elaastic.activity.response.ConfidenceDegree
 import org.elaastic.activity.response.Response
 import org.elaastic.activity.response.ResponseService
 import org.elaastic.activity.results.ItemIndex
-import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.elaastic.ai.evaluation.chatgpt.api.ChatGptCompletionService
 import org.elaastic.assignment.Assignment
 import org.elaastic.sequence.SequenceService
 import org.elaastic.sequence.phase.evaluation.AbstractEvaluationPhaseExecutionController
@@ -26,11 +26,11 @@ class AllAtOnceEvaluationPhaseExecutionController(
     @Autowired override val sequenceService: SequenceService,
     @Autowired val peerGradingService: PeerGradingService,
     @Autowired override val responseService: ResponseService,
-    @Autowired override val chatGptEvaluationService: ChatGptEvaluationService
+    @Autowired override val chatGptCompletionService: ChatGptCompletionService
 ) : AbstractEvaluationPhaseExecutionController(
     sequenceService,
     responseService,
-    chatGptEvaluationService
+    chatGptCompletionService
 ) {
 
     @PostMapping("/submit-evaluation")

--- a/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/draxo/DraxoEvaluationPhaseExecutionController.kt
+++ b/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/draxo/DraxoEvaluationPhaseExecutionController.kt
@@ -5,7 +5,7 @@ import org.elaastic.activity.response.ConfidenceDegree
 import org.elaastic.activity.response.Response
 import org.elaastic.activity.response.ResponseService
 import org.elaastic.activity.results.ItemIndex
-import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.elaastic.ai.evaluation.chatgpt.api.ChatGptCompletionService
 import org.elaastic.assignment.Assignment
 import org.elaastic.sequence.SequenceService
 import org.elaastic.sequence.phase.evaluation.AbstractEvaluationPhaseExecutionController
@@ -26,11 +26,11 @@ class DraxoEvaluationPhaseExecutionController(
     @Autowired override val sequenceService: SequenceService,
     @Autowired val peerGradingService: PeerGradingService,
     @Autowired override val responseService: ResponseService,
-    @Autowired override val chatGptEvaluationService: ChatGptEvaluationService,
+    @Autowired override val chatGptCompletionService: ChatGptCompletionService,
 ) : AbstractEvaluationPhaseExecutionController(
     sequenceService,
     responseService,
-    chatGptEvaluationService
+    chatGptCompletionService
 ) {
 
     @PostMapping("/close-evaluation")

--- a/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/external/ExternalEvaluationPhaseExecutionController.kt
+++ b/server/src/main/kotlin/org/elaastic/sequence/phase/evaluation/external/ExternalEvaluationPhaseExecutionController.kt
@@ -5,7 +5,7 @@ import org.elaastic.activity.response.ConfidenceDegree
 import org.elaastic.activity.response.Response
 import org.elaastic.activity.response.ResponseService
 import org.elaastic.activity.results.ItemIndex
-import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.elaastic.ai.evaluation.chatgpt.api.ChatGptCompletionService
 import org.elaastic.sequence.SequenceService
 import org.elaastic.sequence.phase.evaluation.AbstractEvaluationPhaseExecutionController
 import org.elaastic.user.PrincipalUserResolver
@@ -25,11 +25,11 @@ class ExternalEvaluationPhaseExecutionController(
     @Autowired override val sequenceService: SequenceService,
     @Autowired val peerGradingService: PeerGradingService,
     @Autowired override val responseService: ResponseService,
-    @Autowired override val chatGptEvaluationService: ChatGptEvaluationService
+    @Autowired override val chatGptCompletionService: ChatGptCompletionService
 ) : AbstractEvaluationPhaseExecutionController(
     sequenceService,
     responseService,
-    chatGptEvaluationService
+    chatGptCompletionService
 ) {
     @PostMapping("/finalize")
     fun finalizeEvaluationPhase(

--- a/server/src/main/resources/application-chatgpt.properties
+++ b/server/src/main/resources/application-chatgpt.properties
@@ -17,6 +17,6 @@
 #
 
 # ChatGPT API
-chatgptapi.token= CHANGE ME in config/application-chatgpt.properties which is not versioned
+chatgptapi.token=
 chatgptapi.model=gpt-4o-mini
 chatgptapi.maxTokens=2000

--- a/server/src/main/resources/application-chatgpt.properties
+++ b/server/src/main/resources/application-chatgpt.properties
@@ -1,0 +1,22 @@
+#
+# Elaastic - formative assessment system
+# Copyright (C) 2019. University Toulouse 1 Capitole, University Toulouse 3 Paul Sabatier
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+# ChatGPT API
+chatgptapi.token= CHANGE ME in config/application-chatgpt.properties which is not versioned
+chatgptapi.model=gpt-4o-mini
+chatgptapi.maxTokens=2000

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -126,8 +126,3 @@ rest.api.enabled=true
 rest.api.allowed_url=CHANGE ME in config/application.properties
 rest.user.name=CHANGE ME in config/application.properties
 rest.user.password=CHANGE ME in config/application.properties
-
-# ChatGPT API
-chatgptapi.token= CHANGE ME in config/application.properties
-chatgptapi.model=gpt-4o-mini
-chatgptapi.maxTokens=2000

--- a/server/src/main/resources/togglz.features-file.properties
+++ b/server/src/main/resources/togglz.features-file.properties
@@ -1,3 +1,5 @@
+# Can be overridden by the non-tracked file config/togglz.feature-files.properties
+
 RECOMMENDATIONS=true
 IMPORT_EXPORT=true
 #RECOMMENDATIONS.strategy = show-recommendations
@@ -14,7 +16,9 @@ REVISION_ASSIGNMENT.param.users=fsil,aein
 REVISION_ASSIGNMENT.strategy=username
 REVISION_ASSIGNMENT=true
 
-# CHATGPT_EVALUATION=false or change me in config/togglz.feature-files.properties
+CHATGPT_EVALUATION=true
+CHATGPT_EVALUATION.strategy=spring-profile
+CHATGPT_EVALUATION.param.profiles=chatgpt
 
 # Hide the OIDC login button but keep the OIDC login flow enabled
 SHOW_OIDC_LOGIN=true

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationRepositoryIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationRepositoryIntegrationTest.kt
@@ -14,7 +14,6 @@ import javax.transaction.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@EnabledIf(value = "#{@featureManager.isActive(@featureResolver.getFeature('CHATGPT_EVALUATION'))}", loadContext = true)
 internal class ChatGptEvaluationRepositoryIntegrationTest(
     @Autowired val chatGptEvaluationRepository: ChatGptEvaluationRepository,
     @Autowired val integrationTestingService: IntegrationTestingService,

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationServiceIntegrationTest.kt
@@ -14,17 +14,14 @@ import org.elaastic.test.directive.tWhen
 import org.elaastic.test.interpreter.command.Phase
 import org.elaastic.user.User
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.junit.jupiter.EnabledIf
 import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["no-async"])
-@EnabledIf(value = "#{environment.acceptsProfiles('chatgpt')}", loadContext = true)
 @Transactional
 internal open class ChatGptEvaluationServiceIntegrationTest(
     @Autowired val chatGptEvaluationService: ChatGptEvaluationService,

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationServiceIntegrationTest.kt
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["no-async"])
-@EnabledIf(value = "#{@featureManager.isActive(@featureResolver.getFeature('CHATGPT_EVALUATION'))}", loadContext = true)
+@EnabledIf(value = "#{environment.acceptsProfiles('chatgpt')}", loadContext = true)
 @Transactional
 internal class ChatGptEvaluationServiceIntegrationTest(
     @Autowired val chatGptEvaluationService: ChatGptEvaluationService,

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/ChatGptEvaluationServiceIntegrationTest.kt
@@ -13,8 +13,6 @@ import org.elaastic.test.directive.tThen
 import org.elaastic.test.directive.tWhen
 import org.elaastic.test.interpreter.command.Phase
 import org.elaastic.user.User
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,116 +20,19 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.EnabledIf
-import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["no-async"])
 @EnabledIf(value = "#{environment.acceptsProfiles('chatgpt')}", loadContext = true)
 @Transactional
-internal class ChatGptEvaluationServiceIntegrationTest(
+internal open class ChatGptEvaluationServiceIntegrationTest(
     @Autowired val chatGptEvaluationService: ChatGptEvaluationService,
     @Autowired val integrationTestingService: IntegrationTestingService,
     @Autowired val chatGptEvaluationRepository: ChatGptEvaluationRepository,
     @Autowired val responseRepository: ResponseRepository,
     @Autowired val functionalTestingService: FunctionalTestingService,
-    @Autowired val chatGptPromptService: ChatGptPromptService,
-
     ) {
-
-
-    @BeforeEach
-    @Transactional
-    fun setup() {
-        chatGptEvaluationRepository.deleteAll()
-        // Precondition
-        assertTrue(chatGptEvaluationRepository.findAll().isEmpty())
-        // We want a reasonable good prompt for the test
-        chatGptPromptService.updatePrompt(
-            "Tu es un enseignant bienveillant qui doit évaluer la réponse donnée par un élève"
-                    + " à une question. "
-                    + "Tu dois donner une note comprise entre 0 et 5 à la réponse de l'élève et expliquer"
-                    + " pourquoi tu as donné cette note. Tu dois fournir la réponse sous la forme d'un objet Json ayant " +
-                    "la structure suivante : { \"grade\": \"\", \"annotation\": \"\" } . " +
-                    "Merci de ne pas encapsuler l'objet json dans une enveloppe markdown." +
-                    "La question est fournit dans le JSON suivant contenant la question et la réponse de l'élève et son score sur la base de ce qu'il a choisit comme item.",
-            "fr"
-        )
-    }
-
-    @Test
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    fun `get a chatgpt evaluation - valid`() {
-
-        val response = integrationTestingService.getAnyResponse()
-        response.explanation =
-            "Git est le meilleur système de gestion de version, il coche donc toutes les bonnes options."
-        val promptFr = chatGptPromptService.getPrompt("fr")
-
-        tWhen {
-            chatGptEvaluationService.createEvaluation(response, "fr")
-        }.tThen {
-            assertThat(it.id, notNullValue())
-            assertThat(it.dateCreated, notNullValue())
-            assertThat(it.lastUpdated, notNullValue())
-
-            assertThat(it.status, equalTo("DONE"))
-            assertThat(it.annotation, notNullValue())
-            assertEquals(promptFr, it.prompt)
-
-            assertThat(it.reportReasons, nullValue())
-            assertThat(it.reportComment, nullValue())
-            assertThat(it.utilityGrade, nullValue())
-
-            assertThat(it.hiddenByTeacher, equalTo(false))
-            assertThat(it.removedByTeacher, equalTo(false))
-        }
-    }
-
-    @Test
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    fun `get a chatgpt evaluation - invalid (no teacher explanation)`() {
-
-        val response = integrationTestingService.getAnyResponse()
-        response.explanation =
-            "Git est le meilleur système de gestion de version, il coche donc toutes les bonnes options."
-
-        response.statement.expectedExplanation = null
-
-        tWhen {
-            val block: () -> Unit = {
-                chatGptEvaluationService.createEvaluation(response, "fr")
-            }
-            block
-        }.tThen {
-            assertThrows(
-                IllegalArgumentException::class.java,
-                it,
-                "Error: You must define an expected explanation to create a ChatGPT evaluation"
-            )
-        }
-    }
-
-    @Test
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    fun `get a chatgpt evaluation - invalid (no student answer)`() {
-
-        val response = integrationTestingService.getAnyResponse()
-        response.explanation = null
-
-        tWhen {
-            val block: () -> Unit = {
-                chatGptEvaluationService.createEvaluation(response, "fr")
-            }
-            block
-        }.tThen {
-            assertThrows(
-                IllegalArgumentException::class.java,
-                it,
-                "Error: No explanation to evaluate"
-            )
-        }
-    }
 
     @Test
     fun `canHideGrading should return true if the user is the teacher of the sequence`() {

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
@@ -47,7 +47,7 @@ open class ChatGptCompletionServiceIntegrationTest(
                     + " pourquoi tu as donné cette note. Tu dois fournir la réponse sous la forme d'un objet Json ayant " +
                     "la structure suivante : { \"grade\": \"\", \"annotation\": \"\" } . " +
                     "Merci de ne pas encapsuler l'objet json dans une enveloppe markdown." +
-                    "La question est fournit dans le JSON suivant contenant la question et la réponse de l'élève et son score sur la base de ce qu'il a choisit comme item.",
+                    "La question est fournie dans le JSON suivant contenant la question et la réponse de l'élève et son score sur la base de ce qu'il a choisi comme item.",
             "fr"
         )
     }

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
@@ -1,3 +1,4 @@
+
 package org.elaastic.ai.evaluation.chatgpt.api
 
 import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationRepository
@@ -17,13 +18,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.EnabledIf
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles(profiles = ["no-async"])
+/**
+ * This test requires the real OpenAI API, so it is disabled unless the "chatgpt" profile is active.
+ * We activate the "no-async" profile to avoid asynchronous methods in the test.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = ["spring.profiles.include=no-async"])
 @EnabledIf(value = "#{environment.acceptsProfiles('chatgpt')}", loadContext = true)
 @Transactional
 open class ChatGptCompletionServiceIntegrationTest(

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["no-async"])
-@EnabledIf(value = "#{@featureManager.isActive(@featureResolver.getFeature('CHATGPT_EVALUATION'))}", loadContext = true)
+@EnabledIf(value = "#{environment.acceptsProfiles('chatgpt')}", loadContext = true)
 @Transactional
 class ChatGptCompletionServiceIntegrationTest(
     @Autowired val chatGptCompletionService: ChatGptCompletionService

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 @EnabledIf(value = "#{environment.acceptsProfiles('chatgpt')}", loadContext = true)
 @Transactional
 class ChatGptCompletionServiceIntegrationTest(
-    @Autowired val chatGptCompletionService: ChatGptCompletionService
+    @Autowired val chatGptCompletionService: DefaultChatGptCompletionService
 ) {
 
     @Test

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/api/ChatGptCompletionServiceIntegrationTest.kt
@@ -1,21 +1,101 @@
 package org.elaastic.ai.evaluation.chatgpt.api
 
+import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationRepository
+import org.elaastic.ai.evaluation.chatgpt.prompt.ChatGptPromptService
+import org.elaastic.test.IntegrationTestingService
+import org.elaastic.test.directive.tThen
+import org.elaastic.test.directive.tWhen
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.EnabledIf
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["no-async"])
 @EnabledIf(value = "#{environment.acceptsProfiles('chatgpt')}", loadContext = true)
 @Transactional
-class ChatGptCompletionServiceIntegrationTest(
-    @Autowired val chatGptCompletionService: DefaultChatGptCompletionService
+open class ChatGptCompletionServiceIntegrationTest(
+    @Autowired val integrationTestingService: IntegrationTestingService,
+    @Autowired val chatGptCompletionService: ChatGptCompletionService,
+    @Autowired val chatGptPromptService: ChatGptPromptService,
+    @Autowired val chatGptEvaluationRepository: ChatGptEvaluationRepository,
 ) {
+
+    @BeforeEach
+    @Transactional
+    open fun setup() {
+        chatGptEvaluationRepository.deleteAll()
+        // Precondition
+        assertTrue(chatGptEvaluationRepository.findAll().isEmpty())
+        // We want a reasonable good prompt for the test
+        chatGptPromptService.updatePrompt(
+            "Tu es un enseignant bienveillant qui doit évaluer la réponse donnée par un élève"
+                    + " à une question. "
+                    + "Tu dois donner une note comprise entre 0 et 5 à la réponse de l'élève et expliquer"
+                    + " pourquoi tu as donné cette note. Tu dois fournir la réponse sous la forme d'un objet Json ayant " +
+                    "la structure suivante : { \"grade\": \"\", \"annotation\": \"\" } . " +
+                    "Merci de ne pas encapsuler l'objet json dans une enveloppe markdown." +
+                    "La question est fournit dans le JSON suivant contenant la question et la réponse de l'élève et son score sur la base de ce qu'il a choisit comme item.",
+            "fr"
+        )
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    open fun `get a chatgpt evaluation - invalid (no student answer)`() {
+
+        val response = integrationTestingService.getAnyResponse()
+        response.explanation = null
+
+        tWhen {
+            val block: () -> Unit = {
+                chatGptCompletionService.createEvaluation(response, "fr")
+            }
+            block
+        }.tThen {
+            assertThrows(
+                IllegalArgumentException::class.java,
+                it,
+                "Error: No explanation to evaluate"
+            )
+        }
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    open fun `get a chatgpt evaluation - invalid (no teacher explanation)`() {
+
+        val response = integrationTestingService.getAnyResponse()
+        response.explanation =
+            "Git est le meilleur système de gestion de version, il coche donc toutes les bonnes options."
+
+        response.statement.expectedExplanation = null
+
+        tWhen {
+            val block: () -> Unit = {
+                chatGptCompletionService.createEvaluation(response, "fr")
+            }
+            block
+        }.tThen {
+            assertThrows(
+                IllegalArgumentException::class.java,
+                it,
+                "Error: You must define an expected explanation to create a ChatGPT evaluation"
+            )
+        }
+    }
 
     @Test
     fun testGetChatGptResponseWithOneMessage2Responses() {
@@ -37,6 +117,35 @@ class ChatGptCompletionServiceIntegrationTest(
         println(response.messageList[0].content)
         println("---- second message ----")
         println(response.messageList[1].content)
+    }
+
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    open fun `get a chatgpt evaluation - valid`() {
+
+        val response = integrationTestingService.getAnyResponse()
+        response.explanation =
+            "Git est le meilleur système de gestion de version, il coche donc toutes les bonnes options."
+        val promptFr = chatGptPromptService.getPrompt("fr")
+
+        tWhen {
+            chatGptCompletionService.createEvaluation(response, "fr")
+        }.tThen {
+            assertThat(it.id, notNullValue())
+            assertThat(it.dateCreated, notNullValue())
+            assertThat(it.lastUpdated, notNullValue())
+
+            assertThat(it.status, equalTo("DONE"))
+            assertThat(it.annotation, notNullValue())
+            assertEquals(promptFr, it.prompt)
+
+            assertThat(it.reportReasons, nullValue())
+            assertThat(it.reportComment, nullValue())
+            assertThat(it.utilityGrade, nullValue())
+
+            assertThat(it.hiddenByTeacher, equalTo(false))
+            assertThat(it.removedByTeacher, equalTo(false))
+        }
     }
 
     @Test

--- a/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/prompt/ChatGptPromptServiceIntegrationTest.kt
+++ b/server/src/test/kotlin/org/elaastic/ai/evaluation/chatgpt/prompt/ChatGptPromptServiceIntegrationTest.kt
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["no-async"])
-@EnabledIf(value = "#{@featureManager.isActive(@featureResolver.getFeature('CHATGPT_EVALUATION'))}", loadContext = true)
 @Transactional
 class ChatGptPromptServiceIntegrationTest(
     @Autowired

--- a/server/src/test/kotlin/org/elaastic/player/PlayerControllerTest.kt
+++ b/server/src/test/kotlin/org/elaastic/player/PlayerControllerTest.kt
@@ -25,6 +25,7 @@ import io.mockk.unmockkAll
 import org.elaastic.activity.evaluation.peergrading.PeerGradingService
 import org.elaastic.activity.response.ResponseService
 import org.elaastic.ai.evaluation.chatgpt.ChatGptEvaluationService
+import org.elaastic.ai.evaluation.chatgpt.api.ChatGptCompletionService
 import org.elaastic.analytics.lrs.EventLogService
 import org.elaastic.assignment.Assignment
 import org.elaastic.assignment.AssignmentService
@@ -111,6 +112,9 @@ internal class PlayerControllerTest(
 
     @MockBean
     lateinit var chatGptEvaluationService: ChatGptEvaluationService
+
+    @MockBean
+    lateinit var chatGptCompletionService: ChatGptCompletionService
 
     @MockBean
     lateinit var eventLogService: EventLogService

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -82,8 +82,3 @@ rest.user.password=CHANGE ME in config/application.properties
 # Togglez features file
 
 togglz.features-file.path=config/togglz.features-file.properties
-
-# Chat GPT API
-chatgptapi.token= CHANGE ME in config/application.properties
-chatgptapi.model=gpt-4o-mini
-chatgptapi.maxTokens=2000


### PR DESCRIPTION
Fix [#469](https://github.com/elaastic/elaastic-questions-server/issues/469)

- The dedicated Chat GPT config is moved to `application-chatgpt.properties`
- The service interacting with OpenAI API is mounted only when the "chatgpt" profile is active
- Run the tests requiring an OpenAI API token only when the profile is active
- Always run the otther Chat GPT related tests
- By default, activate the CHATGPT_EVALUATION feature when the "chatgpt" profile is active
- Document the "chatgpt" profile in `server/README.md`

@FranckSilvestre Let me know if you think it can have an impact on the production configuration.