### PR TITLE
fix(player): Fix the start sequence action

### DIFF
--- a/server/src/main/kotlin/org/elaastic/player/PlayerController.kt
+++ b/server/src/main/kotlin/org/elaastic/player/PlayerController.kt
@@ -342,7 +342,7 @@ open class PlayerController(
         authentication: Authentication,
         @PathVariable sequenceId: Long,
         @RequestBody request: SequenceConfig
-    ) {
+    ): Map<String, Any> {
         val user = (authentication.principal as PrincipalUserResolver).elaasticUser
 
         sequenceService.get(user, sequenceId, true)
@@ -355,6 +355,8 @@ open class PlayerController(
                 userService.updateUserActiveSince(user)
                 autoReloadSessionHandler.broadcastReload(sequenceId)
             }
+
+        return mapOf("success" to true)
     }
 
     @ResponseBody

--- a/server/src/main/resources/templates/player/assignment/sequence/components/command/_config-sequence.html
+++ b/server/src/main/resources/templates/player/assignment/sequence/components/command/_config-sequence.html
@@ -55,9 +55,8 @@
                     }).done(function () {
                         window.location.reload();
                     }).fail(function (jqXHR, textStatus, errorThrown) {
-                        console.error('Failed to start sequence:', errorThrown);  // FIXME
-                        console.info({ jqXHR, textStatus, errorThrown })
-                        window.location.reload();
+                        // Note: we should provide an error message to the user here but it will be much easier to implement it in the UI component once authentication is implemented
+                        console.error('Failed to start sequence:', errorThrown);
                     })
                 }
                 elaastic.closeSequenceConfig([[${sequenceId}]]);


### PR DESCRIPTION
Fix https://github.com/elaastic/elaastic-questions-server/issues/502

The fix solely consist in providing a JSON answer in case of success preventing the parsing of an empty response.

Note: I haven't implemented the error handling for providing a feedback to the user when needed. I prefer to delay this to the time we have a clear strategy on UI components integration. This error handling will be much more easily implemented within the UI component.